### PR TITLE
KB-11529 | BE| TECHDEBT| JUnit test cases to improve the code coverage for the cb-notification service.

### DIFF
--- a/src/main/java/com/igot/cb/authentication/util/KeyManager.java
+++ b/src/main/java/com/igot/cb/authentication/util/KeyManager.java
@@ -70,15 +70,16 @@ public class KeyManager {
    * @throws Exception If there's an error during the loading process
    */
   public static PublicKey loadPublicKey(String key) throws Exception {
-    // Remove header and footer from the key string
-    String cleanedKey = key.replaceAll("(-+BEGIN PUBLIC KEY-+)", "")
-            .replaceAll("(-+END PUBLIC KEY-+)", "")
-            .replaceAll("[\\r\\n]+", "");
-    // Decode Base64 content
-    byte[] keyBytes = Base64.getDecoder().decode(cleanedKey);
-    // Generate PublicKey object
-    X509EncodedKeySpec spec = new X509EncodedKeySpec(keyBytes);
-    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-    return keyFactory.generatePublic(spec);
+      String publicKey = new String(key.getBytes(), StandardCharsets.UTF_8);
+      // Remove header and footer from the key string
+      publicKey = publicKey.replaceAll("(-+BEGIN PUBLIC KEY-+)", "");
+      publicKey = publicKey.replaceAll("(-+END PUBLIC KEY-+)", "");
+      publicKey = publicKey.replaceAll("[\\r\\n]+", "");
+      // Decode the key string from Base64
+      byte[] keyBytes = Base64Util.decode(publicKey.getBytes("UTF-8"), Base64Util.DEFAULT);
+      // Convert the key bytes to a PublicKey object
+      X509EncodedKeySpec x509publicKey = new X509EncodedKeySpec(keyBytes);
+      KeyFactory kf = KeyFactory.getInstance("RSA");
+      return kf.generatePublic(x509publicKey);
   }
 }


### PR DESCRIPTION
1.Using slow regular expressions is security-sensitivejava:S5852  - security hotspot.
 2.Updated the code referring to the cb-community-service.