### PR TITLE
KB-13394 | Mandatory Notifications - Mandatory Notification ,List and  Read API for Comprehensive Assessment Program

### DIFF
--- a/src/main/java/com/igot/cb/notification/service/impl/MandatoryNotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/MandatoryNotificationServiceImpl.java
@@ -366,11 +366,16 @@ public class MandatoryNotificationServiceImpl implements MandatoryNotificationSe
             List<Map<String, Object>> records = cassandraOperation.getRecordsByPropertiesWithoutFiltering(
                     keyspace, table, criteria, fields, 1
             );
-            if (CollectionUtils.isEmpty(records) || records.get(0).get(COUNT) == null) {
+            if (CollectionUtils.isEmpty(records)) {
                 log.warn("decrementUnreadCount: No count record found for user {} — skipping", userId);
                 return;
             }
-            int currentCount = (int) records.get(0).get(COUNT);
+            Map<String, Object> countRecord = records.get(0);
+            if (countRecord == null || countRecord.get(COUNT) == null) {
+                log.warn("decrementUnreadCount: No count record found for user {} — skipping", userId);
+                return;
+            }
+            int currentCount = (int) countRecord.get(COUNT);
             if (currentCount <= 0) {
                 log.warn("decrementUnreadCount: Count is already 0 for user {} — skipping", userId);
                 return;

--- a/src/main/java/com/igot/cb/notification/service/impl/MandatoryNotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/MandatoryNotificationServiceImpl.java
@@ -13,6 +13,7 @@ import com.igot.cb.util.Constants;
 import com.igot.cb.util.ProjectUtil;
 import io.micrometer.common.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -249,11 +250,21 @@ public class MandatoryNotificationServiceImpl implements MandatoryNotificationSe
                 updateErrorDetails(response, ERR_INVALID_CREATED_AT_FORMAT, HttpStatus.BAD_REQUEST);
                 return response;
             }
+            Map<String, Object> compositeKey = Map.of(USER_ID, userId, CREATED_AT, createdAt);
+            List<Map<String, Object>> existing = cassandraOperation.getRecordsByPropertiesWithoutFiltering(
+                    Constants.KEYSPACE_SUNBIRD, Constants.TABLE_MANDATORY_NOTIFICATION,
+                    compositeKey, Collections.singletonList(NOTIFICATION_ID), 1
+            );
+            if (CollectionUtils.isEmpty(existing)) {
+                log.warn("markMandatoryNotificationsAsRead: Notification not found for userId={}, createdAt={}", userId, createdAt);
+                updateErrorDetails(response, ERR_NOTIFICATION_NOT_FOUND, HttpStatus.NOT_FOUND);
+                return response;
+            }
             Instant now = Instant.now();
             Map<String, Object> result = cassandraOperation.updateRecordByCompositeKey(
                     Constants.KEYSPACE_SUNBIRD, Constants.TABLE_MANDATORY_NOTIFICATION,
                     Map.of(READ, true, READ_AT, now),
-                    Map.of(USER_ID, userId, CREATED_AT, createdAt)
+                    compositeKey
             );
             if (Constants.SUCCESS.equalsIgnoreCase((String) result.get(Constants.RESPONSE))) {
                 response.getParams().setStatus(Constants.SUCCESS);
@@ -261,6 +272,7 @@ public class MandatoryNotificationServiceImpl implements MandatoryNotificationSe
                 response.setResponseCode(HttpStatus.OK);
                 response.setResult(Map.of(ID, notificationId, READ, true, READ_AT, now.toString()));
                 log.info("markMandatoryNotificationsAsRead: completed");
+                decrementUnreadCount(Constants.KEYSPACE_SUNBIRD, Constants.TABLE_UNREAD_NOTIFICATION_COUNT, userId);
             } else {
                 log.error("markMandatoryNotificationsAsRead: Cassandra update failed for notificationId={}, userId={}", notificationId, userId);
                 updateErrorDetails(response, ERR_FAILED_TO_UPDATE_NOTIFICATION, HttpStatus.INTERNAL_SERVER_ERROR);
@@ -341,5 +353,34 @@ public class MandatoryNotificationServiceImpl implements MandatoryNotificationSe
         response.getParams().setStatus(Constants.FAILED);
         response.getParams().setErrMsg(errorMessage);
         response.setResponseCode(httpStatus);
+    }
+
+    /**
+     * Decrements the unread notification count for the given user by 1.
+     * Count is never decremented below 0. If no record exists, the call is a no-op.
+     */
+    private void decrementUnreadCount(String keyspace, String table, String userId) {
+        try {
+            Map<String, Object> criteria = Map.of(USER_ID, userId);
+            List<String> fields = Collections.singletonList(COUNT);
+            List<Map<String, Object>> records = cassandraOperation.getRecordsByPropertiesWithoutFiltering(
+                    keyspace, table, criteria, fields, 1
+            );
+            if (CollectionUtils.isEmpty(records) || records.get(0).get(COUNT) == null) {
+                log.warn("decrementUnreadCount: No count record found for user {} — skipping", userId);
+                return;
+            }
+            int currentCount = (int) records.get(0).get(COUNT);
+            if (currentCount <= 0) {
+                log.warn("decrementUnreadCount: Count is already 0 for user {} — skipping", userId);
+                return;
+            }
+            Map<String, Object> updates = new HashMap<>();
+            updates.put(COUNT, currentCount - 1);
+            updates.put(UPDATED_AT, Instant.now());
+            cassandraOperation.updateRecordByCompositeKey(keyspace, table, updates, criteria);
+        } catch (Exception e) {
+            log.error("decrementUnreadCount: Failed for user={} error={}", userId, e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -481,6 +481,7 @@ public class Constants {
     public static final String ERR_FETCHING_NOTIFICATION = "Internal server error while fetching notification";
     public static final String ERR_ID_AND_CREATED_AT_REQUIRED = "Both 'id' and 'createdAt' must be provided";
     public static final String ERR_INVALID_CREATED_AT_FORMAT = "Invalid 'createdAt' format";
+    public static final String ERR_NOTIFICATION_NOT_FOUND = "Notification not found for the given id and createdAt";
     public static final String MSG_NOTIFICATION_MARKED_READ = "Notification marked as read successfully";
     public static final String ERR_FAILED_TO_UPDATE_NOTIFICATION = "Failed to update notification";
     public static final String ERR_UPDATING_NOTIFICATION = "Internal server error while updating notification";

--- a/src/test/java/com/igot/cb/notification/service/impl/MandatoryNotificationServiceImplTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/MandatoryNotificationServiceImplTest.java
@@ -626,6 +626,10 @@ class MandatoryNotificationServiceImplTest {
         void validRequest_marksAsRead() {
             mockValidUser();
             String createdAtStr = "2026-02-28T08:00:00Z";
+            when(cassandraOperation.getRecordsByPropertiesWithoutFiltering(
+                    eq(Constants.KEYSPACE_SUNBIRD), eq(Constants.TABLE_MANDATORY_NOTIFICATION),
+                    anyMap(), anyList(), eq(1)
+            )).thenReturn(List.of(Map.of(NOTIFICATION_ID, "n1")));
             when(cassandraOperation.updateRecordByCompositeKey(
                     eq(Constants.KEYSPACE_SUNBIRD), eq(Constants.TABLE_MANDATORY_NOTIFICATION),
                     anyMap(), anyMap()
@@ -642,10 +646,29 @@ class MandatoryNotificationServiceImplTest {
         }
 
         @Test
+        @DisplayName("should return NOT_FOUND when notification does not exist")
+        void notificationNotFound_returnsNotFound() {
+            mockValidUser();
+            when(cassandraOperation.getRecordsByPropertiesWithoutFiltering(
+                    eq(Constants.KEYSPACE_SUNBIRD), eq(Constants.TABLE_MANDATORY_NOTIFICATION),
+                    anyMap(), anyList(), eq(1)
+            )).thenReturn(Collections.emptyList());
+            ApiResponse response = service.markMandatoryNotificationsAsRead(
+                    AUTH_TOKEN, buildRequestBody("n1", "2026-02-28T08:00:00Z"));
+            assertEquals(HttpStatus.NOT_FOUND, response.getResponseCode());
+            assertEquals(ERR_NOTIFICATION_NOT_FOUND, response.getParams().getErrMsg());
+            verify(cassandraOperation, never()).updateRecordByCompositeKey(anyString(), anyString(), anyMap(), anyMap());
+        }
+
+        @Test
         @DisplayName("should pass correct composite key to Cassandra")
         void validRequest_passesCorrectCompositeKey() {
             mockValidUser();
             String createdAtStr = "2026-02-28T08:00:00Z";
+            when(cassandraOperation.getRecordsByPropertiesWithoutFiltering(
+                    eq(Constants.KEYSPACE_SUNBIRD), eq(Constants.TABLE_MANDATORY_NOTIFICATION),
+                    anyMap(), anyList(), eq(1)
+            )).thenReturn(List.of(Map.of(NOTIFICATION_ID, "n1")));
             when(cassandraOperation.updateRecordByCompositeKey(
                     anyString(), anyString(), anyMap(), anyMap()
             )).thenReturn(Map.of(Constants.RESPONSE, Constants.SUCCESS));
@@ -669,6 +692,10 @@ class MandatoryNotificationServiceImplTest {
         @DisplayName("should return INTERNAL_SERVER_ERROR when Cassandra update fails")
         void cassandraUpdateFails_returnsInternalError() {
             mockValidUser();
+            when(cassandraOperation.getRecordsByPropertiesWithoutFiltering(
+                    eq(Constants.KEYSPACE_SUNBIRD), eq(Constants.TABLE_MANDATORY_NOTIFICATION),
+                    anyMap(), anyList(), eq(1)
+            )).thenReturn(List.of(Map.of(NOTIFICATION_ID, "n1")));
             when(cassandraOperation.updateRecordByCompositeKey(
                     anyString(), anyString(), anyMap(), anyMap()
             )).thenReturn(Map.of(Constants.RESPONSE, "failure"));
@@ -682,6 +709,10 @@ class MandatoryNotificationServiceImplTest {
         @DisplayName("should return INTERNAL_SERVER_ERROR on unexpected exception")
         void unexpectedException_returnsInternalError() {
             mockValidUser();
+            when(cassandraOperation.getRecordsByPropertiesWithoutFiltering(
+                    eq(Constants.KEYSPACE_SUNBIRD), eq(Constants.TABLE_MANDATORY_NOTIFICATION),
+                    anyMap(), anyList(), eq(1)
+            )).thenReturn(List.of(Map.of(NOTIFICATION_ID, "n1")));
             when(cassandraOperation.updateRecordByCompositeKey(
                     anyString(), anyString(), anyMap(), anyMap()
             )).thenThrow(new RuntimeException("Connection timeout"));


### PR DESCRIPTION
- Added decrementUnreadCount() to MandatoryNotificationServiceImpl that reads the current count from unread_notification_counts, decrements by 1 (floor 0), and writes it back. Called after a successful mark-as-read Cassandra update.

- Added existence check in markMandatoryNotificationsAsRead before the UPDATE: performs a SELECT on the composite key (user_id, created_at) first; returns 404 NOT_FOUND if no matching row exists, preventing Cassandra's upsert behaviour from creating phantom rows with a wrong createdAt value.

- Added ERR_NOTIFICATION_NOT_FOUND constant to Constants.java.