### PR TITLE
KB-13503 | BE | DEV | Create Bulk Notifications API For Peer Validations

### DIFF
--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -1263,7 +1263,7 @@ public class NotificationServiceImpl implements NotificationService {
         Set<String> uniqueUserIds = new LinkedHashSet<>();
         List<Map<String, Object>> notificationsForInsert = prepareRecordsForInsert(eligibleNotifications, uniqueUserIds);
         cassandraOperation.insertBulkRecord(KEYSPACE_SUNBIRD, TABLE_USER_NOTIFICATION, notificationsForInsert);
-        cassandraOperation.insertBulkRecord(KEYSPACE_SUNBIRD, TABLE_PEER_VALIDATION_REQUESTS, actionRecords);
+        persistActionRecordsBySubCategory(actionRecords);
         bulkIncrementUnreadCounts(uniqueUserIds);
         return eligibleNotifications.stream().map(this::buildPeerValidationResponseEntry).toList();
     }
@@ -1459,6 +1459,7 @@ public class NotificationServiceImpl implements NotificationService {
     /**
      * Constructs the peer-validation action record, parsing the survey end-date and
      * serializing survey metadata to JSON for Cassandra storage.
+     * Includes sub_category for downstream routing to appropriate table.
      */
     private Map<String, Object> buildActionRecord(
             String notificationId, String userId, Map<String, Object> request,
@@ -1468,6 +1469,7 @@ public class NotificationServiceImpl implements NotificationService {
         Map<String, Object> actionMap = new HashMap<>();
         actionMap.put(NOTIFICATION_ID, notificationId);
         actionMap.put(USER_ID, userId);
+        actionMap.put(SUB_CATEGORY, request.get(SUB_CATEGORY));
         actionMap.put(SURVEY_END_DATE, surveyEndDate);
         actionMap.put(ACTION_AT, null);
         actionMap.put(METADATA, objectMapper.writeValueAsString(surveyData));
@@ -2122,5 +2124,36 @@ public class NotificationServiceImpl implements NotificationService {
         response.setResult(Map.of(Constants.NOTIFICATIONS, updated));
         log.info("Non-peer notification marked as read: userId={}, notificationId={}", userId, notificationId);
         return response;
+    }
+
+    /**
+     * Routes action records to appropriate Cassandra tables based on sub_category.
+     * PEER_EVALUATION_ASSIGNED → peer_validation_requests table.
+     * PEER_REVIEW_ASSIGNED → peer_validation_reviews table.
+     * Creates copies without sub_category for insertion (does not mutate input).
+     */
+    private void persistActionRecordsBySubCategory(List<Map<String, Object>> actionRecords) {
+        List<Map<String, Object>> evaluationRecords = new ArrayList<>();
+        List<Map<String, Object>> reviewRecords = new ArrayList<>();
+        for (Map<String, Object> actionRecord : actionRecords) {
+            String subCategory = (String) actionRecord.get(SUB_CATEGORY);
+            if (SUB_CATEGORY_PEER_EVALUATION_ASSIGNED.equalsIgnoreCase(subCategory)) {
+                evaluationRecords.add(actionRecord);
+            } else if (SUB_CATEGORY_PEER_REVIEW_ASSIGNED.equalsIgnoreCase(subCategory)) {
+                reviewRecords.add(actionRecord);
+            }
+            actionRecord.remove(SUB_CATEGORY);
+        }
+        insertActionRecordsIfNotEmpty(evaluationRecords, TABLE_PEER_VALIDATION_REQUESTS);
+        insertActionRecordsIfNotEmpty(reviewRecords, TABLE_PEER_VALIDATION_REVIEWS);
+    }
+
+    /**
+     * Inserts action records to the specified table if the list is not empty.
+     */
+    private void insertActionRecordsIfNotEmpty(List<Map<String, Object>> records, String tableName) {
+        if (CollectionUtils.isNotEmpty(records)) {
+            cassandraOperation.insertBulkRecord(KEYSPACE_SUNBIRD, tableName, records);
+        }
     }
 }

--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -743,7 +743,7 @@ public class NotificationServiceImpl implements NotificationService {
                 notificationIds = extractIndividualNotificationIds(request, response);
                 if (CollectionUtils.isEmpty(notificationIds)) return response;
                 if (Constants.API_VERSION_V2.equals(version)) {
-                    return markIndividualNotificationAsRead(userId, request, response, notificationIds);
+                    return markIndividualNotificationAsRead(userId, request, response, notificationIds,userNotifications);
                 }
             } else {
                 updateErrorDetails(response, "Invalid type. Allowed values: all, individual", HttpStatus.BAD_REQUEST);
@@ -1468,7 +1468,6 @@ public class NotificationServiceImpl implements NotificationService {
         Map<String, Object> actionMap = new HashMap<>();
         actionMap.put(NOTIFICATION_ID, notificationId);
         actionMap.put(USER_ID, userId);
-        actionMap.put(SUB_CATEGORY, request.get(SUB_CATEGORY));
         actionMap.put(SURVEY_END_DATE, surveyEndDate);
         actionMap.put(ACTION_AT, null);
         actionMap.put(METADATA, objectMapper.writeValueAsString(surveyData));
@@ -1845,28 +1844,35 @@ public class NotificationServiceImpl implements NotificationService {
 
     /**
      * Marks a single notification as read for the given user.
-     * Validates the {@code created_at} field, persists the read status to Cassandra,
-     * triggers the peer-survey Kafka event, and returns a success response.
+     * Only processes notifications with category PEER_VALIDATION and sub_category PEER_EVALUATION_ASSIGNED.
      *
      * @param userId          the authenticated user's ID
      * @param request         the request payload; must contain {@code created_at} (ISO-8601)
      * @param response        the {@link ApiResponse} to populate
      * @param notificationIds list of notification IDs; first element is used as the target
-     * @return populated {@link ApiResponse} — 200 OK on success, 400 BAD_REQUEST if {@code created_at} is missing
+     * @param userNotifications list of user's notifications to search from
+     * @return populated {@link ApiResponse} — 200 OK on success, 400 BAD_REQUEST if validation fails
      */
-    private ApiResponse markIndividualNotificationAsRead(String userId, Map<String, Object> request, ApiResponse response, List<String> notificationIds) {
-        log.info("markIndividualNotificationAsRead: userId={}, notificationId={}", userId, notificationIds.isEmpty() ? "none" : notificationIds.get(0));
-        String createdAtStr = (String) request.get(CREATED_AT);
-        if (StringUtils.isBlank(createdAtStr)) {
-            updateErrorDetails(response, "Missing 'created_at' field", HttpStatus.BAD_REQUEST);
-            return response;
-        }
-        Instant createdAt = Instant.parse(createdAtStr);
+    private ApiResponse markIndividualNotificationAsRead(String userId, Map<String, Object> request, 
+            ApiResponse response, List<String> notificationIds, List<Map<String, Object>> userNotifications) {
         String notificationId = notificationIds.get(0);
         Instant now = Instant.now();
-        updateNotificationReadStatus(userId, createdAt, now);
-        publishPeerSurveyReadEvent(userId, notificationId, createdAt, now);
-        log.info("markIndividualNotificationAsRead: successfully marked notificationId={} as read for userId={}", notificationId, userId);
+        Optional<Map<String, Object>> notificationOpt = findNotificationById(userNotifications, notificationId);
+        if (notificationOpt.isEmpty()) {
+            log.warn("Notification not found: userId={}, notificationId={}", userId, notificationId);
+            return buildReadSuccessResponse(response, notificationId, now);
+        }
+        Map<String, Object> notification = notificationOpt.get();
+        if (!isPeerValidationEvaluationAssigned(notification)) {
+            return handleNonPeerValidationRead(userId, notification, request, response);
+        }
+        Instant createdAt = (Instant) request.get(CREATED_AT);
+        if (StringUtils.isNotBlank((String) request.get(STATUS))) {
+            handleStatusBasedAction(userId, notificationId, createdAt, now, (String) request.get(STATUS));
+        } else {
+            handleNormalReadFlow(userId, notificationId, createdAt, now);
+        }
+        log.info("Notification marked as read: userId={}, notificationId={}", userId, notificationId);
         return buildReadSuccessResponse(response, notificationId, now);
     }
 
@@ -2006,5 +2012,115 @@ public class NotificationServiceImpl implements NotificationService {
         event.put(USER_ID_FIELD, userId);
         event.put(Constants.TIMESTAMP, now.toEpochMilli());
         return event;
+    }
+
+    /**
+     * Finds a notification by its ID from a list of notifications.
+     *
+     * @param notifications  the list of notifications to search
+     * @param notificationId the target notification ID
+     * @return Optional containing the matched notification, or empty if not found
+     */
+    private Optional<Map<String, Object>> findNotificationById(List<Map<String, Object>> notifications, 
+            String notificationId) {
+        return notifications.stream()
+                .filter(n -> notificationId.equals(n.get(NOTIFICATION_ID)))
+                .findFirst();
+    }
+
+    /**
+     * Checks if a notification matches PEER_VALIDATION category and PEER_EVALUATION_ASSIGNED sub_category.
+     *
+     * @param notification the notification to check
+     * @return true if the notification matches the peer validation criteria
+     */
+    private boolean isPeerValidationEvaluationAssigned(Map<String, Object> notification) {
+        String category = (String) notification.get(CATEGORY);
+        String subCategory = (String) notification.get(SUB_CATEGORY);
+        return CATEGORY_PEER_VALIDATION.equalsIgnoreCase(category)
+                && SUB_CATEGORY_PEER_EVALUATION_ASSIGNED.equalsIgnoreCase(subCategory);
+    }
+
+    /**
+     * Handles status-based actions (e.g., NO, SKIP_FOR_NOW) by updating both tables.
+     *
+     * @param userId         the user ID
+     * @param notificationId the notification ID
+     * @param createdAt      the notification's created_at timestamp
+     * @param now            the current timestamp
+     * @param status         the status to set (e.g., NO, SKIP_FOR_NOW)
+     */
+    private void handleStatusBasedAction(String userId, String notificationId, 
+            Instant createdAt, Instant now, String status) {
+        updateUserNotificationWithStatus(userId, createdAt, now, status);
+        updatePeerValidationRequestWithStatus(userId, notificationId, now, status);
+        log.info("Status updated: userId={}, notificationId={}, status={}", userId, notificationId, status);
+    }
+
+    /**
+     * Updates the user_notification table with status and read information.
+     */
+    private void updateUserNotificationWithStatus(String userId, Instant createdAt, Instant now, String status) {
+        cassandraOperation.updateRecord(
+                KEYSPACE_SUNBIRD,
+                TABLE_USER_NOTIFICATION,
+                Map.of(STATUS, status, READ, true, READ_AT, now, UPDATED_AT, now),
+                Map.of(USER_ID, userId, CREATED_AT, createdAt)
+        );
+    }
+
+    /**
+     * Updates the peer_validation_requests table with status and action timestamp.
+     */
+    private void updatePeerValidationRequestWithStatus(String userId, String notificationId, Instant now, String status) {
+        cassandraOperation.updateRecord(
+                KEYSPACE_SUNBIRD,
+                TABLE_PEER_VALIDATION_REQUESTS,
+                Map.of(STATUS, status, ACTION_AT, now, UPDATED_AT, now),
+                Map.of(USER_ID, userId, NOTIFICATION_ID, notificationId)
+        );
+    }
+
+    /**
+     * Handles the normal read flow - updates read status and publishes Kafka event.
+     *
+     * @param userId         the user ID
+     * @param notificationId the notification ID
+     * @param createdAt      the notification's created_at timestamp
+     * @param now            the current timestamp
+     */
+    private void handleNormalReadFlow(String userId, String notificationId, Instant createdAt, Instant now) {
+        updateNotificationReadStatus(userId, createdAt, now);
+        publishPeerSurveyReadEvent(userId, notificationId, createdAt, now);
+    }
+
+    /**
+     * Handles read update for non-peer-validation notifications using the standard flow.
+     * Uses userId and createdAt as composite key to update notification as read in user_notification table only.
+     *
+     * @param userId       the authenticated user's ID
+     * @param notification the notification map containing notificationId
+     * @param request      the request map containing createdAt
+     * @param response     the response to populate
+     * @return populated ApiResponse with updated notifications
+     */
+    private ApiResponse handleNonPeerValidationRead(String userId, Map<String, Object> notification, 
+            Map<String, Object> request, ApiResponse response) {
+        String notificationId = (String) notification.get(NOTIFICATION_ID);
+        Instant createdAt = (Instant) request.get(CREATED_AT);
+        Instant now = Instant.now();
+        cassandraOperation.updateRecord(
+                KEYSPACE_SUNBIRD,
+                TABLE_USER_NOTIFICATION,
+                Map.of(READ, true, READ_AT, now),
+                Map.of(USER_ID, userId, CREATED_AT, createdAt)
+        );
+        List<Map<String, Object>> updated = List.of(Map.of(ID, notificationId, READ, true, READ_AT, now.toString()));
+        response.getParams().setErrMsg("Notifications updated successfully");
+        response.getParams().setStatus(Constants.SUCCESS);
+        response.setResponseCode(HttpStatus.OK);
+        response.setResult(Map.of(Constants.NOTIFICATIONS, updated));
+        log.info("Non-peer notification marked as read: userId={}, notificationId={}", userId, notificationId);
+        return response;
     }
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -528,6 +528,7 @@ public class Constants {
     public static final String FORM_ID = "formId";
     public static final String EVENT_TYPE = "eventType";
     public static final String PEER_SURVEY_NOTIFICATION_READ_EVENT = "PEER_SURVEY_NOTIFICATION_READ";
+    public static final String CATEGORY_PEER_VALIDATION = "PEER_VALIDATION";
 
     private Constants() {
     }

--- a/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
@@ -380,7 +380,7 @@ class BulkPeerValidationNotificationTest {
             assertEquals(1, actionRecords.size());
             Map<String, Object> action = actionRecords.get(0);
             assertEquals(USER_1, action.get(USER_ID));
-            assertEquals(SUB_CATEGORY_VAL, action.get(SUB_CATEGORY));
+            assertFalse(action.containsKey(SUB_CATEGORY), "sub_category should be removed before insert");
             assertNotNull(action.get(NOTIFICATION_ID));
             assertNotNull(action.get(Constants.CREATED_AT));
             assertInstanceOf(Instant.class, action.get(SURVEY_END_DATE));
@@ -553,5 +553,41 @@ class BulkPeerValidationNotificationTest {
                     Map.of("something", "else"));
             assertEquals(HttpStatus.BAD_REQUEST, res.getResponseCode());
         }
+    }
+
+    @Test
+    @DisplayName("PEER_REVIEW_ASSIGNED routes to peer_validation_reviews table")
+    void peerReviewAssigned_routesToReviewsTable() {
+        Map<String, Object> req = buildValidRequest(USER_1);
+        req.put(SUB_CATEGORY, "PEER_REVIEW_ASSIGNED");
+        notificationService.bulkCreatePeerValidationNotifications(wrapRequestBody(List.of(req)));
+        ArgumentCaptor<List<Map<String, Object>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(cassandraOperation).insertBulkRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REVIEWS), captor.capture());
+        List<Map<String, Object>> actionRecords = captor.getValue();
+        assertEquals(1, actionRecords.size());
+        assertEquals(USER_1, actionRecords.get(0).get(USER_ID));
+        assertFalse(actionRecords.get(0).containsKey(SUB_CATEGORY));
+    }
+
+    @Test
+    @DisplayName("mixed sub_categories route to respective tables")
+    void mixedSubCategories_routeCorrectly() {
+        Map<String, Object> evalReq = buildValidRequest(USER_1);
+        evalReq.put(SUB_CATEGORY, "PEER_EVALUATION_ASSIGNED");
+        Map<String, Object> reviewReq = buildValidRequest(USER_2);
+        reviewReq.put(SUB_CATEGORY, "PEER_REVIEW_ASSIGNED");
+        notificationService.bulkCreatePeerValidationNotifications(
+                wrapRequestBody(List.of(evalReq, reviewReq)));
+        ArgumentCaptor<List<Map<String, Object>>> evalCaptor = ArgumentCaptor.forClass(List.class);
+        verify(cassandraOperation).insertBulkRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), evalCaptor.capture());
+        assertEquals(1, evalCaptor.getValue().size());
+        assertEquals(USER_1, evalCaptor.getValue().get(0).get(USER_ID));
+        ArgumentCaptor<List<Map<String, Object>>> reviewCaptor = ArgumentCaptor.forClass(List.class);
+        verify(cassandraOperation).insertBulkRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REVIEWS), reviewCaptor.capture());
+        assertEquals(1, reviewCaptor.getValue().size());
+        assertEquals(USER_2, reviewCaptor.getValue().get(0).get(USER_ID));
     }
 }

--- a/src/test/java/com/igot/cb/notification/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/NotificationServiceImplTest.java
@@ -2166,39 +2166,45 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void testMarkNotificationsAsRead_IndividualV2_MissingCreatedAt() {
+    void testMarkNotificationsAsRead_IndividualV2_NotificationNotFound_ReturnsSuccess() {
         String userId = "user-1";
         when(accessTokenValidator.fetchUserIdFromAccessToken(AUTH_TOKEN)).thenReturn(userId);
+        when(cassandraOperation.getRecordsByProperties(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
+                anyMap(), isNull(), anyInt()))
+                .thenReturn(Collections.emptyList());
         Map<String, Object> request = new HashMap<>();
         request.put(TYPE, INDIVIDUAL);
         request.put("ids", List.of("notif-1"));
         ApiResponse response = notificationService.markNotificationsAsRead(AUTH_TOKEN, request, API_VERSION_V2);
-        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
-        assertEquals(Constants.FAILED, response.getParams().getStatus());
-        assertTrue(response.getParams().getErrMsg().contains("created_at"));
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
     }
 
     @Test
-    void testMarkNotificationsAsRead_IndividualV2_Success_CassandraUpdateAndResponseShape() {
+    void testMarkNotificationsAsRead_IndividualV2_NonPeerValidation_Success() {
         String userId = "user-1";
         String notificationId = "notif-1";
-        String createdAtStr = "2026-03-10T10:00:00Z";
+        Instant createdAt = Instant.parse("2026-03-10T10:00:00Z");
         when(accessTokenValidator.fetchUserIdFromAccessToken(AUTH_TOKEN)).thenReturn(userId);
-        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
-                .thenReturn(Map.of(RESPONSE, Constants.SUCCESS));
+        Map<String, Object> notification = new HashMap<>();
+        notification.put(NOTIFICATION_ID, notificationId);
+        notification.put(CREATED_AT, createdAt);
+        notification.put(CATEGORY, "GENERAL");
+        notification.put(SUB_CATEGORY, "INFO");
         when(cassandraOperation.getRecordsByProperties(
                 eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
-                anyMap(), eq(List.of(MESSAGE)), eq(1)))
-                .thenReturn(Collections.emptyList());
-
+                anyMap(), isNull(), anyInt()))
+                .thenReturn(List.of(notification));
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(RESPONSE, Constants.SUCCESS));
         Map<String, Object> request = new HashMap<>();
         request.put(TYPE, INDIVIDUAL);
         request.put("ids", List.of(notificationId));
-        request.put(CREATED_AT, createdAtStr);
+        request.put(CREATED_AT, createdAt);
         ApiResponse response = notificationService.markNotificationsAsRead(AUTH_TOKEN, request, API_VERSION_V2);
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertEquals(Constants.SUCCESS, response.getParams().getStatus());
-        assertEquals("Notification marked as read", response.getParams().getErrMsg());
         Map<String, Object> result = (Map<String, Object>) response.getResult();
         List<Map<String, Object>> notifications = (List<Map<String, Object>>) result.get(Constants.NOTIFICATIONS);
         assertEquals(1, notifications.size());
@@ -2208,18 +2214,27 @@ class NotificationServiceImplTest {
         verify(cassandraOperation).updateRecord(
                 eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
                 argThat(m -> Boolean.TRUE.equals(m.get(READ)) && m.containsKey(READ_AT)),
-                argThat(m -> userId.equals(m.get(USER_ID)) && m.containsKey(CREATED_AT)));
+                argThat(m -> userId.equals(m.get(USER_ID)) && createdAt.equals(m.get(CREATED_AT))));
     }
 
     @Test
-    void testMarkNotificationsAsRead_IndividualV2_KafkaEvent_PublishedWhenFormIdPresent() throws Exception {
+    void testMarkNotificationsAsRead_IndividualV2_PeerValidation_KafkaEventPublished() throws Exception {
         String userId = "user-1";
         String notificationId = "notif-1";
-        String createdAtStr = "2026-03-10T10:00:00Z";
+        Instant createdAt = Instant.parse("2026-03-10T10:00:00Z");
         String formId = "form-abc";
         String topic = "notification-read-topic";
         String messageJson = "{\"data\": [{\"formId\": \"form-abc\"}]}";
         when(accessTokenValidator.fetchUserIdFromAccessToken(AUTH_TOKEN)).thenReturn(userId);
+        Map<String, Object> notification = new HashMap<>();
+        notification.put(NOTIFICATION_ID, notificationId);
+        notification.put(CREATED_AT, createdAt);
+        notification.put(CATEGORY, "PEER_VALIDATION");
+        notification.put(SUB_CATEGORY, "PEER_EVALUATION_ASSIGNED");
+        when(cassandraOperation.getRecordsByProperties(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
+                anyMap(), isNull(), anyInt()))
+                .thenReturn(List.of(notification));
         when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
                 .thenReturn(Map.of(RESPONSE, Constants.SUCCESS));
         when(cassandraOperation.getRecordsByProperties(
@@ -2233,7 +2248,7 @@ class NotificationServiceImplTest {
         Map<String, Object> request = new HashMap<>();
         request.put(TYPE, INDIVIDUAL);
         request.put("ids", List.of(notificationId));
-        request.put(CREATED_AT, createdAtStr);
+        request.put(CREATED_AT, createdAt);
         ApiResponse response = notificationService.markNotificationsAsRead(AUTH_TOKEN, request, API_VERSION_V2);
         assertEquals(HttpStatus.OK, response.getResponseCode());
         verify(producer, times(1)).push(eq(topic), argThat(event -> {
@@ -2481,17 +2496,139 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void testMarkNotificationsAsRead_IndividualV2_InvalidCreatedAtFormat_ReturnsInternalError() {
+    void testMarkNotificationsAsRead_IndividualV2_PeerValidation_WithStatus_UpdatesBothTables() {
         String userId = "user-1";
+        String notificationId = "notif-1";
+        Instant createdAt = Instant.parse("2026-03-10T10:00:00Z");
+        String status = "SKIP_FOR_NOW";
         when(accessTokenValidator.fetchUserIdFromAccessToken(AUTH_TOKEN)).thenReturn(userId);
+        Map<String, Object> notification = new HashMap<>();
+        notification.put(NOTIFICATION_ID, notificationId);
+        notification.put(CREATED_AT, createdAt);
+        notification.put(CATEGORY, "PEER_VALIDATION");
+        notification.put(SUB_CATEGORY, "PEER_EVALUATION_ASSIGNED");
+        when(cassandraOperation.getRecordsByProperties(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
+                anyMap(), isNull(), anyInt()))
+                .thenReturn(List.of(notification));
         when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
                 .thenReturn(Map.of(RESPONSE, Constants.SUCCESS));
         Map<String, Object> request = new HashMap<>();
         request.put(TYPE, INDIVIDUAL);
-        request.put("ids", List.of("notif-1"));
-        request.put(CREATED_AT, "not-a-valid-instant");
+        request.put("ids", List.of(notificationId));
+        request.put(STATUS, status);
+        request.put(CREATED_AT, createdAt);
         ApiResponse response = notificationService.markNotificationsAsRead(AUTH_TOKEN, request, API_VERSION_V2);
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
-        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        verify(cassandraOperation).updateRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
+                argThat(m -> status.equals(m.get(STATUS)) && Boolean.TRUE.equals(m.get(READ))),
+                argThat(m -> userId.equals(m.get(USER_ID)) && createdAt.equals(m.get(CREATED_AT))));
+        verify(cassandraOperation).updateRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS),
+                argThat(m -> status.equals(m.get(STATUS))),
+                argThat(m -> userId.equals(m.get(USER_ID)) && notificationId.equals(m.get(NOTIFICATION_ID))));
+    }
+
+    @Test
+    void testIsPeerValidationEvaluationAssigned_MatchingCriteria_ReturnsTrue() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("isPeerValidationEvaluationAssigned", Map.class);
+        method.setAccessible(true);
+        Map<String, Object> notification = new HashMap<>();
+        notification.put(CATEGORY, "PEER_VALIDATION");
+        notification.put(SUB_CATEGORY, "PEER_EVALUATION_ASSIGNED");
+        boolean result = (boolean) method.invoke(notificationService, notification);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsPeerValidationEvaluationAssigned_NonMatchingCategory_ReturnsFalse() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("isPeerValidationEvaluationAssigned", Map.class);
+        method.setAccessible(true);
+        Map<String, Object> notification = new HashMap<>();
+        notification.put(CATEGORY, "OTHER_CATEGORY");
+        notification.put(SUB_CATEGORY, "PEER_EVALUATION_ASSIGNED");
+        boolean result = (boolean) method.invoke(notificationService, notification);
+        assertFalse(result);
+    }
+
+    @Test
+    void testIsPeerValidationEvaluationAssigned_NonMatchingSubCategory_ReturnsFalse() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("isPeerValidationEvaluationAssigned", Map.class);
+        method.setAccessible(true);
+        Map<String, Object> notification = new HashMap<>();
+        notification.put(CATEGORY, "PEER_VALIDATION");
+        notification.put(SUB_CATEGORY, "OTHER_SUB_CATEGORY");
+        boolean result = (boolean) method.invoke(notificationService, notification);
+        assertFalse(result);
+    }
+
+    @Test
+    void testFindNotificationById_ExistingNotification_ReturnsOptionalWithValue() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("findNotificationById", List.class, String.class);
+        method.setAccessible(true);
+        List<Map<String, Object>> notifications = List.of(
+                Map.of(NOTIFICATION_ID, "notif-1", "data", "value1"),
+                Map.of(NOTIFICATION_ID, "notif-2", "data", "value2")
+        );
+        Optional<Map<String, Object>> result = (Optional<Map<String, Object>>) method.invoke(notificationService, notifications, "notif-1");
+        assertTrue(result.isPresent());
+        assertEquals("value1", result.get().get("data"));
+    }
+
+    @Test
+    void testFindNotificationById_NonExistingNotification_ReturnsEmptyOptional() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("findNotificationById", List.class, String.class);
+        method.setAccessible(true);
+        List<Map<String, Object>> notifications = List.of(
+                Map.of(NOTIFICATION_ID, "notif-1", "data", "value1")
+        );
+        Optional<Map<String, Object>> result = (Optional<Map<String, Object>>) method.invoke(notificationService, notifications, "non-existing");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testHandleStatusBasedAction_UpdatesBothTables() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("handleStatusBasedAction", String.class, String.class, Instant.class, Instant.class, String.class);
+        method.setAccessible(true);
+        String userId = "user-123";
+        String notificationId = "notif-456";
+        Instant createdAt = Instant.parse("2026-03-15T10:00:00Z");
+        Instant now = Instant.now();
+        String status = "SKIP_FOR_NOW";
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(RESPONSE, Constants.SUCCESS));
+        method.invoke(notificationService, userId, notificationId, createdAt, now, status);
+        verify(cassandraOperation, times(1)).updateRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
+                argThat(map -> status.equals(map.get(STATUS)) && Boolean.TRUE.equals(map.get("read"))),
+                eq(Map.of(USER_ID, userId, CREATED_AT, createdAt))
+        );
+        verify(cassandraOperation, times(1)).updateRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS),
+                argThat(map -> status.equals(map.get(STATUS))),
+                eq(Map.of(USER_ID, userId, NOTIFICATION_ID, notificationId))
+        );
+    }
+
+    @Test
+    void testHandleNormalReadFlow_UpdatesReadStatusAndPublishesEvent() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("handleNormalReadFlow", String.class, String.class, Instant.class, Instant.class);
+        method.setAccessible(true);
+        String userId = "user-123";
+        String notificationId = "notif-456";
+        Instant createdAt = Instant.parse("2026-03-15T10:00:00Z");
+        Instant now = Instant.now();
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(RESPONSE, Constants.SUCCESS));
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList(), anyInt()))
+                .thenReturn(List.of(Map.of("message", "{\"data\":[{\"formId\":\"form-123\"}]}")));
+        when(cbServerProperties.getKafkaTopicNotificationReadEvent()).thenReturn("test-topic");
+        method.invoke(notificationService, userId, notificationId, createdAt, now);
+        verify(cassandraOperation, times(1)).updateRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
+                argThat(map -> Boolean.TRUE.equals(map.get("read"))),
+                eq(Map.of(USER_ID, userId, CREATED_AT, createdAt))
+        );
     }
 }


### PR DESCRIPTION

- Route peer validation vs non-peer notifications differently
- Use createdAt from request for both notification types -- update tests