### PR TITLE
KB-13503 | BE | DEV | Create Bulk Notifications API For Peer Validations

### DIFF
--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -1369,6 +1369,8 @@ public class NotificationServiceImpl implements NotificationService {
                 cbServerProperties.isPeerValidationNotificationSettingCheckEnabled()
                         ? fetchUserNotificationSettings(requestList)
                         : Collections.emptyMap();
+        Instant baseTime = Instant.now();
+        int recordIndex = 0;
         for (Map<String, Object> request : requestList) {
             String userId = (String) request.get(USER_ID);
             String notificationType = (String) request.get(TYPE);
@@ -1378,7 +1380,11 @@ public class NotificationServiceImpl implements NotificationService {
                         SUB_CATEGORY, request.get(SUB_CATEGORY), REASON, NOTIFICATION_TYPE_DISABLED));
                 continue;
             }
-            buildRecordsForRequest(request, userId, notificationType, eligibleNotifications, actionRecords, failures);
+            // so Cassandra's (user_id, created_at) composite key is unique per row.
+            // Cassandra timestamp has millisecond precision, so sub-ms offsets would be truncated and collide.
+            Instant createdAt = baseTime.plusMillis(recordIndex * cbServerProperties.getPeerValidationBulkCreatedAtOffsetMs());
+            buildRecordsForRequest(request, userId, notificationType, eligibleNotifications, actionRecords, failures, createdAt);
+            recordIndex++;
         }
         log.info("Built {} notification records, {} skipped, {} failures",
                 eligibleNotifications.size(), skipped.size(), failures.size());
@@ -1399,23 +1405,26 @@ public class NotificationServiceImpl implements NotificationService {
     /**
      * Builds one notification record and one action record for a single user request.
      * On failure, adds an error entry to {@code failures} instead of propagating the exception.
+     *
+     * @param createdAt a pre-generated, per-record unique timestamp; prevents
+     *                  {@code created_at} collisions on Cassandra's (user_id, created_at) composite key
      */
     private void buildRecordsForRequest(
             Map<String, Object> request, String userId, String notificationType,
             List<Map<String, Object>> eligibleNotifications,
             List<Map<String, Object>> actionRecords,
-            List<Map<String, Object>> failures) {
+            List<Map<String, Object>> failures,
+            Instant createdAt) {
         try {
             Map<String, Object> message = (Map<String, Object>) request.get(MESSAGE);
             List<Map<String, Object>> dataList = (List<Map<String, Object>>) message.get(DATA);
             Map<String, Object> surveyData = dataList.get(0);
-            Instant now = Instant.now();
             String notificationId = java.util.UUID.randomUUID().toString();
 
             Map<String, Object> notificationRecord = buildNotificationRecord(
-                    notificationId, userId, notificationType, request, now);
+                    notificationId, userId, notificationType, request, createdAt);
             Map<String, Object> actionRecord = buildActionRecord(
-                    notificationId, userId, request, surveyData, now);
+                    notificationId, userId, request, surveyData, createdAt);
 
             eligibleNotifications.add(notificationRecord);
             actionRecords.add(actionRecord);

--- a/src/main/java/com/igot/cb/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbServerProperties.java
@@ -61,4 +61,7 @@ public class CbServerProperties {
 
   @Value("${kafka.topic.notification.read.event}")
   private String kafkaTopicNotificationReadEvent;
+
+  @Value("${peervalidation.bulk.created.at.offset.ms}")
+  private long peerValidationBulkCreatedAtOffsetMs;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,3 +75,4 @@ kafka.topic.process.peer.validation=dev.peer.validation.status.update
 kafka.group.process.peer.validation=dev.peer.validation.status.consumer.group
 kafka.topic.process.peer.validation.error=dev.peer.validation.status.update.error
 kafka.topic.notification.read.event=dev.peer.survey.notification.read
+peervalidation.bulk.created.at.offset.ms=100


### PR DESCRIPTION
Each record in a bulk create now receives a unique timestamp offset by `peervalidation.bulk.created.at.offset.ms` (default 100 ms) per record, preventing Cassandra's (user_id, created_at) composite key from collapsing all rows into a single insert when Instant.now() resolves to the same millisecond across the batch.