### PR TITLE
KB-13516 | BE | DEV | Implementation of the API for Survery Dashboard

### DIFF
--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -1606,9 +1606,10 @@ public class NotificationServiceImpl implements NotificationService {
 
             int maxFetch = cbServerProperties.getPeerValidationListMaxFetch();
             Instant fromDate = ZonedDateTime.now(ZoneOffset.UTC).minusDays(days).toInstant();
+            List<String> excludedStatuses = resolveExcludedStatusesForSubType(subType);
 
             List<Map<String, Object>> records = fetchPeerValidationRecords(tableName, userId, maxFetch);
-            List<Map<String, Object>> filtered = filterSortAndLimit(records, fromDate);
+            List<Map<String, Object>> filtered = filterSortAndLimit(records, fromDate, excludedStatuses);
 
             int total = filtered.size();
             int fromIndex = Math.min(page * size, total);
@@ -1655,26 +1656,6 @@ public class NotificationServiceImpl implements NotificationService {
                 null,
                 maxFetch
         );
-    }
-
-    /**
-     * Retains only records within the {@code fromDate} window, excludes SUBMITTED status, and sorts them newest-first.
-     */
-    private List<Map<String, Object>> filterSortAndLimit(
-            List<Map<String, Object>> records, Instant fromDate) {
-        return records.stream()
-                .filter(r -> {
-                    Instant createdAt = getInstant(r.get(CREATED_AT));
-                    if (ObjectUtils.isEmpty(createdAt) || createdAt.isBefore(fromDate)) {
-                        return false;
-                    }
-                    String status = (String) r.get(STATUS);
-                    return !Constants.STATUS_SUBMITTED.equalsIgnoreCase(status);
-                })
-                .sorted(Comparator.comparing(
-                        r -> getInstant(r.get(CREATED_AT)),
-                        Comparator.reverseOrder()))
-                .toList();
     }
 
     /**
@@ -2263,5 +2244,108 @@ public class NotificationServiceImpl implements NotificationService {
                 Map.of(USER_ID, userId, CREATED_AT, createdAt)
         );
         log.info("Updated user_notification status to '{}' for userId: {}", status, userId);
+    }
+
+    /**
+     * Returns the configured list of statuses to exclude from the peer-validation list
+     * response, based on the given subType.
+     * <ul>
+     *   <li>{@code PEER_EVALUATION_ASSIGNED} → e.g. {@code ["SUBMITTED", "IGNORED"]}</li>
+     *   <li>{@code PEER_REVIEW_ASSIGNED} → e.g. {@code ["APPROVED", "REJECTED"]}</li>
+     * </ul>
+     *
+     * @param subType the peer-validation sub-type string
+     * @return list of status strings to exclude; never {@code null}
+     */
+    private List<String> resolveExcludedStatusesForSubType(String subType) {
+        log.debug("Resolving excluded statuses for subType={}", subType);
+        if (SUB_CATEGORY_PEER_EVALUATION_ASSIGNED.equalsIgnoreCase(subType)) {
+            return cbServerProperties.getPeerEvaluationAssignedExcludedStatuses();
+        }
+        return cbServerProperties.getPeerReviewAssignedExcludedStatuses();
+    }
+
+    /**
+     * Applies in-memory expiry marking, filters, sorts, and returns the processed records.
+     * <p>
+     * Pipeline (in order):
+     * <ol>
+     *   <li>Mark each PENDING record whose {@code survey_end_date} is in the past as {@code EXPIRED}
+     *       (in-memory only — no Cassandra write).</li>
+     *   <li>Exclude records whose {@code created_at} is before {@code fromDate}.</li>
+     *   <li>Exclude records whose {@code status} is in {@code excludedStatuses}.</li>
+     *   <li>Sort survivors by {@code created_at} ascending (oldest first).</li>
+     * </ol>
+     *
+     * @param records          raw records fetched from Cassandra
+     * @param fromDate         lower-bound cutoff; records created before this instant are excluded
+     * @param excludedStatuses status values to filter out; may be {@code null} or empty
+     * @return filtered, sorted list — never {@code null}
+     */
+    private List<Map<String, Object>> filterSortAndLimit(
+            List<Map<String, Object>> records, Instant fromDate, List<String> excludedStatuses) {
+        log.debug("filterSortAndLimit: input={} records, fromDate={}, excludedStatuses={}",
+                records.size(), fromDate, excludedStatuses);
+        Set<String> exclusionSet = CollectionUtils.isEmpty(excludedStatuses)
+                ? Collections.emptySet() : new HashSet<>(excludedStatuses);
+        Instant now = Instant.now();
+        records.forEach(r -> markAsExpiredIfEligible(r, now));
+        List<Map<String, Object>> result = records.stream()
+                .filter(r -> isWithinDateWindow(r, fromDate) && isStatusAllowed(r, exclusionSet))
+                .sorted(Comparator.comparing(r -> getInstant(r.get(CREATED_AT))))
+                .toList();
+        log.debug("filterSortAndLimit: output={} records after filtering and sorting", result.size());
+        return result;
+    }
+
+    /**
+     * Mutates a single record in-memory by setting its {@code status} to {@code EXPIRED}
+     * when all of the following hold:
+     * <ul>
+     *   <li>The current status is {@code PENDING} (case-insensitive).</li>
+     *   <li>A {@code survey_end_date} is present on the record.</li>
+     *   <li>{@code survey_end_date} is strictly before {@code now}.</li>
+     * </ul>
+     * Non-PENDING records are skipped immediately. No Cassandra write is performed.
+     *
+     * @param record the peer-validation record map to evaluate and potentially mutate
+     * @param now    the reference instant used as the expiry threshold
+     */
+    private void markAsExpiredIfEligible(Map<String, Object> record, Instant now) {
+        if (!Constants.STATUS_PENDING.equalsIgnoreCase((String) record.get(STATUS))) {
+            return;
+        }
+        Instant surveyEndDate = getInstant(record.get(SURVEY_END_DATE));
+        if (!ObjectUtils.isEmpty(surveyEndDate) && surveyEndDate.isBefore(now)) {
+            record.put(STATUS, Constants.STATUS_EXPIRED);
+            log.info("Marked record as EXPIRED in-memory: userId={}, notificationId={}",
+                    record.get(USER_ID), record.get(NOTIFICATION_ID));
+        }
+    }
+
+    /**
+     * Returns {@code true} if the record's {@code created_at} is on or after {@code fromDate}.
+     * Records with a missing or unparseable {@code created_at} are excluded.
+     *
+     * @param notifRecord the peer-validation record map
+     * @param fromDate    the lower-bound cutoff instant
+     * @return {@code true} if the record falls within the requested date window
+     */
+    private boolean isWithinDateWindow(Map<String, Object> notifRecord, Instant fromDate) {
+        Instant createdAt = getInstant(notifRecord.get(CREATED_AT));
+        return !ObjectUtils.isEmpty(createdAt) && !createdAt.isBefore(fromDate);
+    }
+
+    /**
+     * Returns {@code true} if the record's {@code status} is not present in the exclusion set.
+     * A {@code null} status is treated as allowed.
+     *
+     * @param notifRecord  the peer-validation record map
+     * @param exclusionSet set of status strings to reject; must not be {@code null}
+     * @return {@code true} if the status is absent from the exclusion set
+     */
+    private boolean isStatusAllowed(Map<String, Object> notifRecord, Set<String> exclusionSet) {
+        String status = (String) notifRecord.get(STATUS);
+        return StringUtils.isBlank(status) || !exclusionSet.contains(status);
     }
 }

--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -521,7 +521,7 @@ public class NotificationServiceImpl implements NotificationService {
                     Constants.KEYSPACE_SUNBIRD,
                     Constants.TABLE_USER_NOTIFICATION,
                     Map.of(USER_ID, userId),
-                    List.of(NOTIFICATION_ID, CREATED_AT, TYPE, MESSAGE, READ, ROLE, SOURCE, CATEGORY, SUB_CATEGORY, SUB_TYPE, IS_DELETED),
+                    List.of(NOTIFICATION_ID, CREATED_AT, TYPE, MESSAGE, READ, ROLE, SOURCE, CATEGORY, SUB_CATEGORY, SUB_TYPE, IS_DELETED, STATUS),
                     MAX_NOTIFICATIONS_FETCH_FOR_READ
             );
 

--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -1855,6 +1855,10 @@ public class NotificationServiceImpl implements NotificationService {
             return buildReadSuccessResponse(response, notificationId, now);
         }
         Map<String, Object> notification = notificationOpt.get();
+        if (Boolean.TRUE.equals(notification.get(READ))) {
+            log.info("Notification already read: userId={}, notificationId={}", userId, notificationId);
+            return buildAlreadyReadResponse(response, notificationId);
+        }
         if (!isPeerValidationEvaluationAssigned(notification)) {
             return handleNonPeerValidationRead(userId, notification, request, response);
         }
@@ -2347,5 +2351,22 @@ public class NotificationServiceImpl implements NotificationService {
     private boolean isStatusAllowed(Map<String, Object> notifRecord, Set<String> exclusionSet) {
         String status = (String) notifRecord.get(STATUS);
         return StringUtils.isBlank(status) || !exclusionSet.contains(status);
+    }
+
+        /**
+     * Assembles a 200 OK {@link ApiResponse} indicating the notification was already read.
+     *
+     * @param response       the response object to populate
+     * @param notificationId the ID of the notification that was already read
+     * @return the populated {@link ApiResponse}
+     */
+    private ApiResponse buildAlreadyReadResponse(ApiResponse response, String notificationId) {
+        response.getParams().setErrMsg("Notification is already marked as read");
+        response.getParams().setStatus(Constants.SUCCESS);
+        response.setResponseCode(HttpStatus.OK);
+        response.setResult(Map.of(Constants.NOTIFICATIONS, List.of(
+                Map.of(ID, notificationId, READ, true)
+        )));
+        return response;
     }
 }

--- a/src/main/java/com/igot/cb/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbServerProperties.java
@@ -1,5 +1,6 @@
 package com.igot.cb.util;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
@@ -70,4 +71,10 @@ public class CbServerProperties {
 
   @Value("${kafka.topic.notification.bulk.create.error}")
   private String kafkaTopicNotificationBulkCreateError;
+
+  @Value("#{'${notification.list.peer.evaluation.assigned.excluded.statuses}'.split(',')}")
+  private List<String> peerEvaluationAssignedExcludedStatuses;
+
+  @Value("#{'${notification.list.peer.review.assigned.excluded.statuses}'.split(',')}")
+  private List<String> peerReviewAssignedExcludedStatuses;
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -532,6 +532,7 @@ public class Constants {
     public static final String EVENT_TYPE = "eventType";
     public static final String PEER_SURVEY_NOTIFICATION_READ_EVENT = "PEER_SURVEY_NOTIFICATION_READ";
     public static final String CATEGORY_PEER_VALIDATION = "PEER_VALIDATION";
+    public static final String STATUS_EXPIRED = "EXPIRED";
 
     private Constants() {
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -82,3 +82,7 @@ kafka.topic.process.peer.evaluation.error=dev.peer.evaluation.status.update.erro
 kafka.topic.notification.bulk.create=dev.notification.bulk.create
 kafka.group.notification.bulk.create=dev.notification.bulk.create.consumer.group
 kafka.topic.notification.bulk.create.error=dev.notification.bulk.create.error
+
+# Status values to exclude from notification list API per subType
+notification.list.peer.evaluation.assigned.excluded.statuses=SUBMITTED,IGNORED
+notification.list.peer.review.assigned.excluded.statuses=APPROVED,REJECTED

--- a/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
@@ -3,6 +3,7 @@ package com.igot.cb.notification.service.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.notification.entity.NotificationSettingEntity;
 import com.igot.cb.notification.repository.NotificationSettingRepository;
+import com.igot.cb.producer.Producer;
 import com.igot.cb.util.CbServerProperties;
 import com.igot.cb.util.Constants;
 
@@ -42,6 +43,9 @@ class BulkPeerValidationNotificationTest {
 
     @Mock
     private CbServerProperties cbServerProperties;
+
+    @Mock
+    private Producer producer;
 
     private final ObjectMapper realMapper = new ObjectMapper();
 
@@ -790,6 +794,115 @@ class BulkPeerValidationNotificationTest {
             Map<?, ?> result = (Map<?, ?>) res.getResult();
             assertEquals(0, result.get(Constants.TOTAL_COUNT));
             assertTrue(((List<?>) result.get(NOTIFICATIONS)).isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Mark as read — idempotency guard")
+    class MarkAsReadIdempotencyTests {
+        private static final String V2_TOKEN = "v2-auth-token";
+        private static final String V2_USER_ID = "v2-user-abc";
+        private static final String NOTIF_ID = "notif-id-001";
+
+        @BeforeEach
+        void setUp() {
+            when(accessTokenValidator.fetchUserIdFromAccessToken(V2_TOKEN)).thenReturn(V2_USER_ID);
+        }
+
+        private Map<String, Object> buildNotification(boolean read, String category, String subCategory) {
+            Map<String, Object> notif = new HashMap<>();
+            notif.put(NOTIFICATION_ID, MarkAsReadIdempotencyTests.NOTIF_ID);
+            notif.put(READ, read);
+            notif.put(CATEGORY, category);
+            notif.put(SUB_CATEGORY, subCategory);
+            notif.put(CREATED_AT, Instant.now().minusSeconds(60));
+            return notif;
+        }   
+
+        private Map<String, Object> buildMarkReadRequest() {
+            Map<String, Object> request = new HashMap<>();
+            request.put(TYPE, Constants.INDIVIDUAL);
+            request.put(IDS, List.of(MarkAsReadIdempotencyTests.NOTIF_ID));
+            request.put(CREATED_AT, Instant.now().minusSeconds(60));
+            return request;
+        }
+
+        @Test
+        @DisplayName("already-read PEER_VALIDATION notification → 200 OK with 'already marked' message")
+        void alreadyRead_peerValidation_returnsAlreadyMarkedResponse() {
+            Map<String, Object> alreadyRead = buildNotification(
+                    true, Constants.CATEGORY_PEER_VALIDATION, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED);
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(alreadyRead));
+            ApiResponse res = notificationService.markNotificationsAsRead(
+                    V2_TOKEN, buildMarkReadRequest(), Constants.API_VERSION_V2);
+            assertEquals(HttpStatus.OK, res.getResponseCode());
+            assertEquals("Notification is already marked as read", res.getParams().getErrMsg());
+            List<?> notifications = (List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS);
+            assertEquals(1, notifications.size());
+            assertEquals(true, ((Map<?, ?>) notifications.get(0)).get(READ));
+        }
+
+        @Test
+        @DisplayName("already-read notification → no Cassandra updateRecord invoked")
+        void alreadyRead_peerValidation_noCassandraWrite() {
+            Map<String, Object> alreadyRead = buildNotification(
+                    true, Constants.CATEGORY_PEER_VALIDATION, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED);
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(alreadyRead));
+            notificationService.markNotificationsAsRead(
+                    V2_TOKEN, buildMarkReadRequest(), Constants.API_VERSION_V2);
+            verify(cassandraOperation, never()).updateRecord(
+                    anyString(), anyString(), anyMap(), anyMap());
+        }
+
+        @Test
+        @DisplayName("already-read non-peer notification → 200 OK with 'already marked' message")
+        void alreadyRead_nonPeerValidation_returnsAlreadyMarkedResponse() {
+            Map<String, Object> alreadyRead = buildNotification(
+                    true, "OTHER_CATEGORY", "OTHER_SUB");
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(alreadyRead));
+            ApiResponse res = notificationService.markNotificationsAsRead(
+                    V2_TOKEN, buildMarkReadRequest(), Constants.API_VERSION_V2);
+            assertEquals(HttpStatus.OK, res.getResponseCode());
+            assertEquals("Notification is already marked as read", res.getParams().getErrMsg());
+        }
+
+        @Test
+        @DisplayName("unread notification → Cassandra updateRecord is called and response is 200 OK")
+        void unread_peerValidation_normalFlowProceedsAndUpdatesDb() {
+            Map<String, Object> unread = buildNotification(
+                    false, Constants.CATEGORY_PEER_VALIDATION, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED);
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(unread));
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION), anyMap(), anyList(), eq(1)))
+                    .thenReturn(Collections.emptyList());
+            when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                    .thenReturn(Map.of(Constants.RESPONSE, Constants.SUCCESS));
+            ApiResponse res = notificationService.markNotificationsAsRead(
+                    V2_TOKEN, buildMarkReadRequest(), Constants.API_VERSION_V2);
+            assertEquals(HttpStatus.OK, res.getResponseCode());
+            verify(cassandraOperation, atLeastOnce()).updateRecord(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION), anyMap(), anyMap());
+        }
+
+        @Test
+        @DisplayName("notification not found in user list → treated as success (no write)")
+        void notificationNotFound_returnsSuccessWithNoWrite() {
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION), anyMap(), isNull(), eq(100)))
+                    .thenReturn(Collections.emptyList());
+            ApiResponse res = notificationService.markNotificationsAsRead(
+                    V2_TOKEN, buildMarkReadRequest(), Constants.API_VERSION_V2);
+            assertEquals(HttpStatus.OK, res.getResponseCode());
+            verify(cassandraOperation, never()).updateRecord(
+                    anyString(), anyString(), anyMap(), anyMap());
         }
     }
 

--- a/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
@@ -590,4 +590,207 @@ class BulkPeerValidationNotificationTest {
         assertEquals(1, reviewCaptor.getValue().size());
         assertEquals(USER_2, reviewCaptor.getValue().get(0).get(USER_ID));
     }
+
+    @Nested
+    @DisplayName("Get peer validation notifications list")
+    class GetPeerValidationListTests {
+        private static final String TEST_TOKEN = "list-test-token";
+        private static final String TEST_USER_ID = "list-user-abc";
+        @BeforeEach
+        void setUp() {
+            when(accessTokenValidator.fetchUserIdFromAccessToken(TEST_TOKEN)).thenReturn(TEST_USER_ID);
+            when(cbServerProperties.getPeerValidationListMaxFetch()).thenReturn(100);
+            when(cbServerProperties.getPeerEvaluationAssignedExcludedStatuses())
+                    .thenReturn(List.of("SUBMITTED", "IGNORED"));
+            when(cbServerProperties.getPeerReviewAssignedExcludedStatuses())
+                    .thenReturn(List.of("APPROVED", "REJECTED"));
+        }
+        private Map<String, Object> buildRecord(String status, Instant createdAt) {
+            Map<String, Object> r = new HashMap<>();
+            r.put(Constants.STATUS, status);
+            r.put(Constants.CREATED_AT, createdAt);
+            r.put(Constants.USER_ID, TEST_USER_ID);
+            r.put(NOTIFICATION_ID, java.util.UUID.randomUUID().toString());
+            return r;
+        }
+        private Map<String, Object> buildRecordWithSurveyEndDate(String status, Instant createdAt, Instant surveyEndDate) {
+            Map<String, Object> r = buildRecord(status, createdAt);
+            r.put(Constants.SURVEY_END_DATE, surveyEndDate);
+            return r;
+        }
+        @Test
+        @DisplayName("invalid auth token → BAD_REQUEST")
+        void invalidAuthToken_returnsBadRequest() {
+            when(accessTokenValidator.fetchUserIdFromAccessToken(TEST_TOKEN)).thenReturn("");
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            assertEquals(HttpStatus.BAD_REQUEST, res.getResponseCode());
+        }
+        @Test
+        @DisplayName("unknown subType → BAD_REQUEST")
+        void unknownSubType_returnsBadRequest() {
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, "UNKNOWN_TYPE", 7, 0, 10);
+            assertEquals(HttpStatus.BAD_REQUEST, res.getResponseCode());
+        }
+        @Test
+        @DisplayName("PEER_EVALUATION_ASSIGNED excludes SUBMITTED and IGNORED statuses")
+        void peerEvaluationAssigned_excludesSubmittedAndIgnoredStatuses() {
+            Instant now = Instant.now();
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecord("PENDING", now.minusSeconds(10)),
+                            buildRecord("SUBMITTED", now.minusSeconds(20)),
+                            buildRecord("IGNORED", now.minusSeconds(30))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            assertEquals(HttpStatus.OK, res.getResponseCode());
+            List<?> list = (List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS);
+            assertEquals(1, list.size());
+            assertEquals("PENDING", ((Map<?, ?>) list.get(0)).get(Constants.STATUS));
+        }
+        @Test
+        @DisplayName("PEER_REVIEW_ASSIGNED excludes APPROVED and REJECTED statuses")
+        void peerReviewAssigned_excludesApprovedAndRejectedStatuses() {
+            Instant now = Instant.now();
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REVIEWS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecord("PENDING", now.minusSeconds(10)),
+                            buildRecord("APPROVED", now.minusSeconds(20)),
+                            buildRecord("REJECTED", now.minusSeconds(30))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_REVIEW_ASSIGNED, 7, 0, 10);
+            assertEquals(HttpStatus.OK, res.getResponseCode());
+            List<?> list = (List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS);
+            assertEquals(1, list.size());
+            assertEquals("PENDING", ((Map<?, ?>) list.get(0)).get(Constants.STATUS));
+        }
+        @Test
+        @DisplayName("SUBMITTED status is excluded — status values from DB are uppercase")
+        void submittedStatus_isExcluded() {
+            Instant now = Instant.now();
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecord("SUBMITTED", now.minusSeconds(10)),
+                            buildRecord("PENDING", now.minusSeconds(20))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            List<?> list = (List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS);
+            assertEquals(1, list.size());
+            assertEquals("PENDING", ((Map<?, ?>) list.get(0)).get(Constants.STATUS));
+        }
+        @Test
+        @DisplayName("PENDING record with expired survey_end_date is marked EXPIRED in response")
+        void pendingRecord_withExpiredSurveyEndDate_isMarkedExpiredInResponse() {
+            Instant now = Instant.now();
+            when(cbServerProperties.getPeerEvaluationAssignedExcludedStatuses())
+                    .thenReturn(Collections.emptyList());
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecordWithSurveyEndDate("PENDING", now.minusSeconds(10),
+                                    now.minus(1, ChronoUnit.DAYS))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            List<?> list = (List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS);
+            assertEquals(1, list.size());
+            assertEquals(Constants.STATUS_EXPIRED, ((Map<?, ?>) list.get(0)).get(Constants.STATUS));
+        }
+        @Test
+        @DisplayName("PENDING record with future survey_end_date remains PENDING")
+        void pendingRecord_withFutureSurveyEndDate_remainsPending() {
+            Instant now = Instant.now();
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecordWithSurveyEndDate("PENDING", now.minusSeconds(10),
+                                    now.plus(7, ChronoUnit.DAYS))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            List<?> list = (List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS);
+            assertEquals(1, list.size());
+            assertEquals("PENDING", ((Map<?, ?>) list.get(0)).get(Constants.STATUS));
+        }
+        @Test
+        @DisplayName("non-PENDING record with expired survey_end_date status is unchanged")
+        void nonPendingRecord_withExpiredSurveyEndDate_statusUnchanged() {
+            Instant now = Instant.now();
+            when(cbServerProperties.getPeerEvaluationAssignedExcludedStatuses())
+                    .thenReturn(Collections.emptyList());
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecordWithSurveyEndDate("SUBMITTED", now.minusSeconds(10),
+                                    now.minus(1, ChronoUnit.DAYS))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            List<?> list = (List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS);
+            assertEquals(1, list.size());
+            assertEquals("SUBMITTED", ((Map<?, ?>) list.get(0)).get(Constants.STATUS));
+        }
+        @Test
+        @DisplayName("EXPIRED status is filtered out when EXPIRED is in exclusion config")
+        void expiredStatus_isFiltered_whenInExclusionConfig() {
+            Instant now = Instant.now();
+            when(cbServerProperties.getPeerEvaluationAssignedExcludedStatuses())
+                    .thenReturn(List.of("SUBMITTED", "IGNORED", "EXPIRED"));
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecordWithSurveyEndDate("PENDING", now.minusSeconds(10),
+                                    now.minus(1, ChronoUnit.DAYS)),
+                            buildRecord("PENDING", now.minusSeconds(20))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            List<?> list = (List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS);
+            assertEquals(1, list.size());
+            assertEquals("PENDING", ((Map<?, ?>) list.get(0)).get(Constants.STATUS));
+        }
+        @Test
+        @DisplayName("records outside day window are excluded")
+        void recordsOutsideDayWindow_areExcluded() {
+            Instant now = Instant.now();
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecord("PENDING", now.minusSeconds(60)),
+                            buildRecord("PENDING", now.minus(30, ChronoUnit.DAYS))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            assertEquals(1, ((List<?>) ((Map<?, ?>) res.getResult()).get(NOTIFICATIONS)).size());
+        }
+        @Test
+        @DisplayName("pagination returns correct page subset and total count")
+        void pagination_returnsCorrectSubsetAndTotalCount() {
+            Instant now = Instant.now();
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(List.of(
+                            buildRecord("PENDING", now.minusSeconds(10)),
+                            buildRecord("PENDING", now.minusSeconds(20)),
+                            buildRecord("PENDING", now.minusSeconds(30))));
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 1, 1);
+            Map<?, ?> result = (Map<?, ?>) res.getResult();
+            assertEquals(3, result.get(Constants.TOTAL_COUNT));
+            assertEquals(1, ((List<?>) result.get(NOTIFICATIONS)).size());
+        }
+        @Test
+        @DisplayName("no records returns OK with empty list and zero total")
+        void noRecords_returnsOkWithEmptyListAndZeroTotal() {
+            when(cassandraOperation.getRecordsByProperties(
+                    eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS), anyMap(), isNull(), eq(100)))
+                    .thenReturn(Collections.emptyList());
+            ApiResponse res = notificationService.getPeerValidationNotifications(
+                    TEST_TOKEN, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED, 7, 0, 10);
+            assertEquals(HttpStatus.OK, res.getResponseCode());
+            Map<?, ?> result = (Map<?, ?>) res.getResult();
+            assertEquals(0, result.get(Constants.TOTAL_COUNT));
+            assertTrue(((List<?>) result.get(NOTIFICATIONS)).isEmpty());
+        }
+    }
+
 }


### PR DESCRIPTION
- Mark PENDING records with past survey_end_date as EXPIRED in-memory before filtering; no Cassandra write performed
- Change sort order to ascending (oldest first) by created_at
- Update GetPeerValidationListTests: fix case-sensitive status test, add 4 new tests covering EXPIRED marking, future dates, non-PENDING records, and config-driven EXPIRED exclusion