### PR TITLE
KB-13516 |BE | DEV | Implementation of the API for Survery Dashboard

### DIFF
--- a/src/main/java/com/igot/cb/notification/controller/NotificationController.java
+++ b/src/main/java/com/igot/cb/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.igot.cb.notification.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.igot.cb.peervalidationcleanup.service.PeerValidationCleanupService;
 import com.igot.cb.notification.enums.NotificationReadStatus;
 import com.igot.cb.notification.service.NotificationService;
 import com.igot.cb.util.Constants;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,9 +23,12 @@ import static com.igot.cb.util.Constants.*;
 public class NotificationController {
 
     private NotificationService notificationService;
+    private final PeerValidationCleanupService peerValidationCleanupService;
 
-    public NotificationController(NotificationService notificationService) {
+    public NotificationController(NotificationService notificationService,
+                                  PeerValidationCleanupService peerValidationCleanupService) {
         this.notificationService = notificationService;
+        this.peerValidationCleanupService = peerValidationCleanupService;
     }
 
     @PostMapping("/create")
@@ -140,6 +145,13 @@ public class NotificationController {
         Map<String, Object> request = (Map<String, Object>) requestBody.get(REQUEST);
         ApiResponse response = notificationService.markNotificationsAsRead(token, request, Constants.API_VERSION_V2);
         return ResponseEntity.ok(response);
+    }
+
+
+    @PostMapping(Constants.CLEANUP_PEER_VALIDATION_ENDPOINT)
+    public ResponseEntity<Void> runPeerValidationCleanup() {
+        peerValidationCleanupService.runCleanup(Instant.now());
+        return ResponseEntity.accepted().build();
     }
 
 }

--- a/src/main/java/com/igot/cb/notification/controller/NotificationController.java
+++ b/src/main/java/com/igot/cb/notification/controller/NotificationController.java
@@ -59,9 +59,9 @@ public class NotificationController {
             @RequestParam(defaultValue = Constants.DEFAULT_NOTIFICATION_PAGE + "") int page,
             @RequestParam(defaultValue = Constants.DEFAULT_NOTIFICATION_PAGE_SIZE + "") int size,
             @RequestParam(defaultValue = Constants.DEFAULT_NOTIFICATION_READ_STATUS) NotificationReadStatus status,
-            @RequestParam(required = false) String subType) {
+            @RequestParam(required = false) String sub_type) {
 
-        ApiResponse response = notificationService.getNotificationsByUserIdAndLastXDays(token, days, page, size, status, subType);
+        ApiResponse response = notificationService.getNotificationsByUserIdAndLastXDays(token, days, page, size, status, sub_type);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -1573,13 +1573,9 @@ public class NotificationServiceImpl implements NotificationService {
         if (!(firstEntry instanceof Map)) return ERR_MESSAGE_DATA_REQUIRED;
         Map<String, Object> surveyData = (Map<String, Object>) firstEntry;
 
-        String surveyEndDateStr = Objects.toString(surveyData.get(SURVEY_END_DATE_KEY), null);
-        if (StringUtils.isBlank(surveyEndDateStr)) return ERR_SURVEY_END_DATE_REQUIRED;
-        try {
-            Instant.parse(surveyEndDateStr);
-        } catch (Exception e) {
-            log.warn("Invalid surveyEndDate format: {}", surveyEndDateStr);
-            return ERR_SURVEY_END_DATE_FORMAT;
+        if (SUB_CATEGORY_PEER_EVALUATION_ASSIGNED.equalsIgnoreCase(subCategoryStr)
+                || SUB_CATEGORY_PEER_REVIEW_ASSIGNED.equalsIgnoreCase(subCategoryStr)) {
+            return validateSurveyEndDate(surveyData);
         }
         return null;
     }
@@ -2294,7 +2290,7 @@ public class NotificationServiceImpl implements NotificationService {
         records.forEach(r -> markAsExpiredIfEligible(r, now));
         List<Map<String, Object>> result = records.stream()
                 .filter(r -> isWithinDateWindow(r, fromDate) && isStatusAllowed(r, exclusionSet))
-                .sorted(Comparator.comparing(r -> getInstant(r.get(CREATED_AT))))
+                .sorted(Comparator.comparing(r -> getInstant(r.get(SURVEY_END_DATE))))
                 .toList();
         log.debug("filterSortAndLimit: output={} records after filtering and sorting", result.size());
         return result;
@@ -2313,15 +2309,15 @@ public class NotificationServiceImpl implements NotificationService {
      * @param record the peer-validation record map to evaluate and potentially mutate
      * @param now    the reference instant used as the expiry threshold
      */
-    private void markAsExpiredIfEligible(Map<String, Object> record, Instant now) {
-        if (!Constants.STATUS_PENDING.equalsIgnoreCase((String) record.get(STATUS))) {
+    private void markAsExpiredIfEligible(Map<String, Object> notifRecord, Instant now) {
+        if (!Constants.STATUS_PENDING.equalsIgnoreCase((String) notifRecord.get(STATUS))) {
             return;
         }
-        Instant surveyEndDate = getInstant(record.get(SURVEY_END_DATE));
+        Instant surveyEndDate = getInstant(notifRecord.get(SURVEY_END_DATE));
         if (!ObjectUtils.isEmpty(surveyEndDate) && surveyEndDate.isBefore(now)) {
-            record.put(STATUS, Constants.STATUS_EXPIRED);
+            notifRecord.put(STATUS, Constants.STATUS_EXPIRED);
             log.info("Marked record as EXPIRED in-memory: userId={}, notificationId={}",
-                    record.get(USER_ID), record.get(NOTIFICATION_ID));
+                    notifRecord.get(USER_ID), notifRecord.get(NOTIFICATION_ID));
         }
     }
 
@@ -2367,4 +2363,23 @@ public class NotificationServiceImpl implements NotificationService {
         )));
         return response;
     }
+
+    /**
+     * Validates the presence and ISO-8601 format of the {@code survey_end_date} field in the input map.
+     *
+     * @param surveyData the input map containing survey data
+     * @return {@code null} if validation passes; otherwise, an error message string describing the failure
+     */
+    private String validateSurveyEndDate(Map<String, Object> surveyData) {
+        String surveyEndDateStr = Objects.toString(surveyData.get(SURVEY_END_DATE_KEY), null);
+        if (StringUtils.isBlank(surveyEndDateStr)) return ERR_SURVEY_END_DATE_REQUIRED;
+        try {
+            Instant.parse(surveyEndDateStr);
+            return null;
+        } catch (Exception e) {
+            log.warn("Invalid surveyEndDate format: {}", surveyEndDateStr);
+            return ERR_SURVEY_END_DATE_FORMAT;
+        }
+    }
+
 }

--- a/src/main/java/com/igot/cb/peervalidationcleanup/service/PeerValidationCleanupService.java
+++ b/src/main/java/com/igot/cb/peervalidationcleanup/service/PeerValidationCleanupService.java
@@ -1,0 +1,9 @@
+package com.igot.cb.peervalidationcleanup.service;
+
+import java.time.Instant;
+
+
+public interface PeerValidationCleanupService {
+
+    void runCleanup(Instant jobInstant);
+}

--- a/src/main/java/com/igot/cb/peervalidationcleanup/service/PeerValidationCleanupServiceImpl.java
+++ b/src/main/java/com/igot/cb/peervalidationcleanup/service/PeerValidationCleanupServiceImpl.java
@@ -1,0 +1,721 @@
+package com.igot.cb.peervalidationcleanup.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.igot.cb.util.CbServerProperties;
+import com.igot.cb.util.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.igot.common.cassandra.CassandraOperation;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
+
+/**
+ * Default implementation of {@link PeerValidationCleanupService}.
+ *
+ * <p>Reads time-windowed Kafka events for the previous calendar day, deserializes each
+ * event, and removes the corresponding row from the peer-validation action table in
+ * Cassandra. Every successful deletion is audited by inserting a record into
+ * {@code peer_validation_cleanup_failures} for traceability. Failures are only logged
+ * and never written to the database.
+ */
+@Service
+@Slf4j
+public class PeerValidationCleanupServiceImpl implements PeerValidationCleanupService {
+
+
+    private static final TypeReference<Map<String, Object>> EVENT_TYPE_REF = new TypeReference<>() {
+    };
+
+    private final CbServerProperties cbServerProperties;
+    private final CassandraOperation cassandraOperation;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Epoch-ms lower and upper bounds for a single day's cleanup window.
+     */
+    record TimeWindow(long startMs, long endMs) {
+    }
+
+    /**
+     * Fully validated, ready-to-delete cleanup event extracted from a Kafka message.
+     */
+    record CleanupEvent(
+            String userId,
+            String notificationId,
+            Instant createdAt,
+            String actionTable) {
+    }
+
+    /**
+     * Per-run counts returned to {@link #runCleanup} for summary logging.
+     */
+    record CleanupSummary(int eligible, int deleted, int failed) {
+    }
+
+    public PeerValidationCleanupServiceImpl(CbServerProperties cbServerProperties,
+                                            CassandraOperation cassandraOperation,
+                                            ObjectMapper objectMapper) {
+        this.cbServerProperties = cbServerProperties;
+        this.cassandraOperation = cassandraOperation;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Entry point for the cleanup job.
+     *
+     * <p>Derives the target date from {@code jobInstant} (UTC), then reads Kafka events
+     * for that day in a fully pipelined fashion. Events are accumulated into chunks of
+     * {@code cleanup.peer.validation.batch.size} and each chunk is processed in parallel
+     * using a fixed thread pool of size {@code cleanup.peer.validation.thread.pool.size}.
+     * The executor blocks ({@code invokeAll}) until a chunk is fully processed before the
+     * next chunk is accepted, providing explicit back-pressure and bounding both memory
+     * usage and the number of in-flight Cassandra operations.
+     *
+     * @param jobInstant reference instant supplied by the scheduler
+     */
+    @Override
+    public void runCleanup(Instant jobInstant) {
+        LocalDate targetDate = LocalDate.ofInstant(jobInstant, ZoneOffset.UTC).minusDays(cbServerProperties.getCleanupDayOffset());
+        log.info("runCleanup: starting for date={} (jobInstant={})", targetDate, jobInstant);
+        int chunkSize = cbServerProperties.getCleanupBatchSize();
+        ExecutorService executor = Executors.newFixedThreadPool(cbServerProperties.getCleanupThreadPoolSize());
+        LongAdder eventsRead = new LongAdder();
+        LongAdder eligible = new LongAdder();
+        LongAdder deleted = new LongAdder();
+        LongAdder failed = new LongAdder();
+        List<String> chunk = new ArrayList<>(chunkSize);
+        try {
+            readKafkaEventsForDay(targetDate, raw -> {
+                eventsRead.increment();
+                chunk.add(raw);
+                if (chunk.size() >= chunkSize) {
+                    processChunk(List.copyOf(chunk), targetDate, executor, eligible, deleted, failed);
+                    chunk.clear();
+                }
+            });
+            if (!chunk.isEmpty()) {
+                processChunk(List.copyOf(chunk), targetDate, executor, eligible, deleted, failed);
+            }
+        } finally {
+            shutdownExecutor(executor);
+        }
+
+        log.info("runCleanup: completed date={} eventsRead={} eligible={} deleted={} failed={}",
+                targetDate, eventsRead.sum(), eligible.sum(), deleted.sum(), failed.sum());
+    }
+
+    /**
+     * Shuts down the given executor and waits for task completion up to
+     * {@code cleanup.peer.validation.executor.shutdown.timeout.minutes} minutes.
+     *
+     * @param executor the executor to shut down
+     */
+    private void shutdownExecutor(ExecutorService executor) {
+        executor.shutdown();
+        try {
+            int timeoutMinutes = cbServerProperties.getCleanupExecutorShutdownTimeoutMinutes();
+            if (!executor.awaitTermination(timeoutMinutes, TimeUnit.MINUTES)) {
+                log.warn("shutdownExecutor: did not terminate within {} minutes", timeoutMinutes);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("shutdownExecutor: interrupted while awaiting executor shutdown");
+        }
+    }
+
+    /**
+     * Submits a chunk of raw event strings to the executor as parallel tasks and blocks
+     * until the entire chunk is processed ({@code invokeAll} semantics).
+     *
+     * <p>Each task deletes its row individually (one {@code deleteRecord} call) then
+     * returns the built audit {@link Map} on success, or {@code null} on any failure.
+     * After all tasks complete, non-null audit records are flushed together with a single
+     * {@code insertBulkRecord} call — replacing N individual audit inserts with one.
+     *
+     * @param chunk      list of raw JSON event strings to process
+     * @param targetDate the job date passed through to each delete/audit operation
+     * @param executor   the fixed-size thread pool to submit tasks to
+     * @param eligible   thread-safe counter for events that passed validation
+     * @param deleted    thread-safe counter for successfully deleted rows
+     * @param failed     thread-safe counter for validation or Cassandra failures
+     */
+    private void processChunk(List<String> chunk, LocalDate targetDate, ExecutorService executor,
+                              LongAdder eligible, LongAdder deleted, LongAdder failed) {
+        List<Callable<Map<String, Object>>> tasks = chunk.stream()
+                .<Callable<Map<String, Object>>>map(
+                        raw -> () -> executeDeleteTask(raw, targetDate, eligible, deleted, failed))
+                .toList();
+
+        List<Map<String, Object>> auditRecords = invokeAndCollectAuditMaps(tasks, executor);
+        if (!auditRecords.isEmpty()) {
+            bulkPersistAudit(auditRecords);
+        }
+    }
+
+    /**
+     * Validates and deletes a single raw event. Returns an audit map on success,
+     * or {@code null} if validation fails or a Cassandra error occurs.
+     *
+     * @param raw        raw JSON event string
+     * @param targetDate job date for the audit record
+     * @param eligible   incremented when the event passes validation
+     * @param deleted    incremented on successful row deletion
+     * @param failed     incremented on validation failure or Cassandra error
+     * @return the audit record map on success, or an empty map on validation/Cassandra failure
+     */
+    private Map<String, Object> executeDeleteTask(String raw, LocalDate targetDate,
+                                                  LongAdder eligible, LongAdder deleted,
+                                                  LongAdder failed) {
+        Optional<CleanupEvent> event = parseAndValidate(raw);
+        if (event.isEmpty()) {
+            failed.increment();
+            return Map.of();
+        }
+        CleanupEvent ce = event.get();
+        eligible.increment();
+        try {
+            deleteActionRecord(ce);
+            log.debug("executeDeleteTask: deleted notificationId={} table={}", ce.notificationId(), ce.actionTable());
+            deleted.increment();
+            return buildAuditRecord(ce, targetDate);
+        } catch (Exception e) {
+            log.error("executeDeleteTask: Cassandra delete failed notificationId={}: {}",
+                    ce.notificationId(), e.getMessage(), e);
+            failed.increment();
+            return Map.of();
+        }
+    }
+
+    /**
+     * Submits tasks via {@code invokeAll} and collects non-empty results.
+     * Returns an empty list if the calling thread is interrupted.
+     *
+     * @param tasks    callable tasks, each returning an audit map (empty map signals failure)
+     * @param executor the executor to invoke tasks on
+     * @return list of audit maps with at least one entry from successful tasks
+     */
+    private List<Map<String, Object>> invokeAndCollectAuditMaps(
+            List<Callable<Map<String, Object>>> tasks, ExecutorService executor) {
+        try {
+            List<Future<Map<String, Object>>> futures = executor.invokeAll(tasks);
+            return futures.stream()
+                    .map(f -> {
+                        try {
+                            return f.get();
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            return Map.<String, Object>of();
+                        } catch (Exception e) {
+                            return Map.<String, Object>of();
+                        }
+                    })
+                    .filter(m -> !m.isEmpty())
+                    .toList();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("invokeAndCollectAuditMaps: interrupted while waiting for chunk completion");
+            return List.of();
+        }
+    }
+
+    /**
+     * Reads all Kafka messages from every configured cleanup topic whose broker
+     * timestamp falls within [00:01:00, 23:59:59] UTC on {@code targetDate} and
+     * passes each raw JSON value directly to {@code eventHandler} as it arrives,
+     * so no full-day list is ever held in memory.
+     *
+     * @param targetDate   the day to scan
+     * @param eventHandler called once per in-window message value
+     */
+    private void readKafkaEventsForDay(LocalDate targetDate, Consumer<String> eventHandler) {
+        TimeWindow window = buildTimeWindow(targetDate);
+        List<String> topics = resolveKafkaTopics();
+        log.info("readKafkaEventsForDay: topics={}", topics);
+
+        try (KafkaConsumer<String, String> consumer = createKafkaConsumer()) {
+            for (String topic : topics) {
+                LongAdder topicCount = new LongAdder();
+                readTopic(consumer, topic, window, raw -> {
+                    topicCount.increment();
+                    eventHandler.accept(raw);
+                });
+                log.info("readKafkaEventsForDay: topic={} events={}", topic, topicCount.sum());
+            }
+        }
+    }
+
+    /**
+     * Resolves the list of Kafka topics to scan.
+     *
+     * @return ordered list of non-blank topic names
+     */
+    private List<String> resolveKafkaTopics() {
+        return parseTopics(cbServerProperties.getCleanupKafkaTopics());
+    }
+
+    /**
+     * Builds the UTC epoch-ms time window for a given date.
+     *
+     * <p>The window starts at 00:01:00 (skipping midnight to avoid boundary edge cases)
+     * and ends at 23:59:59 to cover the full working day.
+     *
+     * @param date the target calendar date
+     * @return a {@link TimeWindow} with {@code startMs} and {@code endMs}
+     */
+    private TimeWindow buildTimeWindow(LocalDate date) {
+        LocalTime windowStart = LocalTime.parse(cbServerProperties.getCleanupWindowStartTime());
+        LocalTime windowEnd = LocalTime.parse(cbServerProperties.getCleanupWindowEndTime());
+        long startMs = ZonedDateTime.of(date, windowStart, ZoneOffset.UTC).toInstant().toEpochMilli();
+        long endMs = ZonedDateTime.of(date, windowEnd, ZoneOffset.UTC).toInstant().toEpochMilli();
+        return new TimeWindow(startMs, endMs);
+    }
+
+    /**
+     * Parses a comma-separated topic string into a trimmed, non-empty list.
+     *
+     * <p>Guards against trailing commas or extra whitespace in the properties value.
+     *
+     * @param raw comma-separated topic names from configuration
+     * @return ordered list of non-blank topic names
+     */
+    private List<String> parseTopics(String raw) {
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(t -> !t.isBlank())
+                .toList();
+    }
+
+    /**
+     * Reads all messages from a single topic within the given time window,
+     * forwarding each in-window value immediately to {@code eventHandler}.
+     *
+     * @param consumer     the Kafka consumer to use
+     * @param topic        the topic name to scan
+     * @param window       the epoch-ms time window
+     * @param eventHandler called once per in-window message value
+     */
+    private void readTopic(KafkaConsumer<String, String> consumer, String topic, TimeWindow window,
+                           Consumer<String> eventHandler) {
+        List<PartitionInfo> partitionInfos = consumer.partitionsFor(topic);
+        if (partitionInfos == null || partitionInfos.isEmpty()) {
+            log.warn("readTopic: no partitions found for topic={}", topic);
+            return;
+        }
+
+        List<TopicPartition> allPartitions = toTopicPartitions(partitionInfos);
+        consumer.assign(allPartitions);
+
+        Set<TopicPartition> activePartitions = resolveActivePartitions(consumer, allPartitions, window.startMs());
+        if (activePartitions.isEmpty()) {
+            return;
+        }
+
+        Map<TopicPartition, Long> endOffsets = consumer.endOffsets(allPartitions);
+        collectWindowedRecords(consumer, activePartitions, endOffsets, window, eventHandler);
+    }
+
+    /**
+     * Converts a list of {@link PartitionInfo} to a list of {@link TopicPartition}.
+     *
+     * @param partitionInfos partition metadata from the broker
+     * @return topic-partition identifiers used by the consumer API
+     */
+    private List<TopicPartition> toTopicPartitions(List<PartitionInfo> partitionInfos) {
+        return partitionInfos.stream()
+                .map(pi -> new TopicPartition(pi.topic(), pi.partition()))
+                .toList();
+    }
+
+    /**
+     * For each partition, seeks to the first offset at or after {@code startMs}.
+     * Partitions with no data at or after {@code startMs}, or already at log-end, are excluded.
+     *
+     * @param consumer      the Kafka consumer
+     * @param allPartitions all partitions of the topic
+     * @param startMs       the epoch-ms lower bound
+     * @return partitions that have been seeked and are ready for polling
+     */
+    private Set<TopicPartition> resolveActivePartitions(KafkaConsumer<String, String> consumer,
+                                                        List<TopicPartition> allPartitions,
+                                                        long startMs) {
+        Map<TopicPartition, Long> timestampQuery = new HashMap<>();
+        allPartitions.forEach(tp -> timestampQuery.put(tp, startMs));
+
+        Map<TopicPartition, OffsetAndTimestamp> startOffsets = consumer.offsetsForTimes(timestampQuery);
+        Map<TopicPartition, Long> endOffsets = consumer.endOffsets(allPartitions);
+
+        Set<TopicPartition> active = new HashSet<>();
+        for (TopicPartition tp : allPartitions) {
+            OffsetAndTimestamp ots = startOffsets.get(tp);
+            Long endOffset = endOffsets.get(tp);
+            if (ots != null && endOffset != null && endOffset > ots.offset()) {
+                consumer.seek(tp, ots.offset());
+                active.add(tp);
+            }
+        }
+        return active;
+    }
+
+    /**
+     * Polls the consumer in a loop, forwarding each in-window message value to
+     * {@code eventHandler} immediately — no intermediate list is created.
+     * A partition is marked exhausted when a record's timestamp exceeds
+     * {@code endMs} or the record reaches the pre-fetched log-end offset.
+     *
+     * @param consumer         the Kafka consumer
+     * @param activePartitions mutable set of partitions still being drained
+     * @param endOffsets       pre-fetched log-end offsets per partition
+     * @param window           the epoch-ms time window
+     * @param eventHandler     called once per in-window message value
+     */
+    private void collectWindowedRecords(KafkaConsumer<String, String> consumer,
+                                        Set<TopicPartition> activePartitions,
+                                        Map<TopicPartition, Long> endOffsets,
+                                        TimeWindow window,
+                                        Consumer<String> eventHandler) {
+        while (!activePartitions.isEmpty()) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(cbServerProperties.getCleanupPollTimeoutSeconds()));
+            if (records.isEmpty()) {
+                break;
+            }
+            Set<TopicPartition> exhausted = new HashSet<>();
+            for (ConsumerRecord<String, String> kafkaRecord : records) {
+                processRecord(kafkaRecord, endOffsets, window, eventHandler, exhausted);
+            }
+            activePartitions.removeAll(exhausted);
+        }
+    }
+
+    /**
+     * Evaluates a single Kafka record against the time window.
+     *
+     * <p>Invokes {@code eventHandler} with the message value if the timestamp is within
+     * bounds, and marks the partition as exhausted when the record surpasses the window
+     * end or reaches the log-end offset.
+     *
+     * @param kafkaRecord  the Kafka record to evaluate
+     * @param endOffsets   pre-fetched log-end offsets per partition
+     * @param window       the epoch-ms time window
+     * @param eventHandler called with the message value when it falls within the window
+     * @param exhausted    accumulator for partitions that should stop being polled
+     */
+    private void processRecord(ConsumerRecord<String, String> kafkaRecord,
+                               Map<TopicPartition, Long> endOffsets,
+                               TimeWindow window,
+                               Consumer<String> eventHandler,
+                               Set<TopicPartition> exhausted) {
+        TopicPartition tp = new TopicPartition(kafkaRecord.topic(), kafkaRecord.partition());
+
+        if (kafkaRecord.timestamp() > window.endMs()) {
+            exhausted.add(tp);
+            return;
+        }
+
+        if (kafkaRecord.timestamp() >= window.startMs()) {
+            eventHandler.accept(kafkaRecord.value());
+        }
+
+        Long endOffset = endOffsets.get(tp);
+        if (endOffset != null && kafkaRecord.offset() >= endOffset - 1) {
+            exhausted.add(tp);
+        }
+    }
+
+    /**
+     * Iterates over raw Kafka event strings, parses and validates each one, and deletes
+     * the corresponding Cassandra rows. Validation and delete failures are only logged;
+     * successful deletions are written to the audit table.
+     *
+     * <p>Package-private to allow direct unit-test access without a full Kafka mock setup.
+     *
+     * @param rawEvents  list of raw JSON strings from Kafka
+     * @param targetDate the cleanup job date used in audit records
+     * @return a {@link CleanupSummary} with counts of eligible, deleted, and failed rows
+     */
+    CleanupSummary processCleanupEvents(List<String> rawEvents, LocalDate targetDate) {
+        int eligible = 0;
+        int deleted = 0;
+        int failed = 0;
+        List<Map<String, Object>> auditRecords = new ArrayList<>();
+        for (String raw : rawEvents) {
+            Optional<CleanupEvent> event = parseAndValidate(raw);
+            if (event.isEmpty()) {
+                failed++;
+                continue;
+            }
+            CleanupEvent ce = event.get();
+            eligible++;
+            try {
+                deleteActionRecord(ce);
+                auditRecords.add(buildAuditRecord(ce, targetDate));
+                deleted++;
+            } catch (Exception e) {
+                log.error("processCleanupEvents: Cassandra delete failed notificationId={}: {}",
+                        ce.notificationId(), e.getMessage(), e);
+                failed++;
+            }
+        }
+        if (!auditRecords.isEmpty()) {
+            bulkPersistAudit(auditRecords);
+        }
+        return new CleanupSummary(eligible, deleted, failed);
+    }
+
+    /**
+     * Parses and fully validates a raw JSON event string into a {@link CleanupEvent}.
+     * Returns {@link Optional#empty()} if parsing or any validation step fails.
+     *
+     * @param raw the raw JSON event string
+     * @return an {@link Optional} containing the validated event, or empty
+     */
+    private Optional<CleanupEvent> parseAndValidate(String raw) {
+        Map<String, Object> eventMap = parseEventJson(raw);
+        if (eventMap.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(extractCleanupEvent(eventMap));
+    }
+
+    /**
+     * Parses a raw JSON string into a map.
+     * Returns {@code null} and logs a warning if parsing fails.
+     *
+     * @param raw the raw JSON string
+     * @return the parsed map, or an empty map if parsing fails
+     */
+    private Map<String, Object> parseEventJson(String raw) {
+        try {
+            return objectMapper.readValue(raw, EVENT_TYPE_REF);
+        } catch (Exception e) {
+            log.warn("parseEventJson: JSON parse error: {}", e.getMessage());
+            return Map.of();
+        }
+    }
+
+    /**
+     * Extracts and validates all required fields from a parsed event map, then builds a
+     * {@link CleanupEvent}. Returns {@code null} and logs a warning if any field is
+     * missing, blank, or unrecognised.
+     *
+     * @param event the parsed event map
+     * @return a validated {@link CleanupEvent}, or {@code null} on validation failure
+     */
+    private CleanupEvent extractCleanupEvent(Map<String, Object> event) {
+        String userId = asString(event, Constants.USER_ID_FIELD);
+        String notificationId = asString(event, Constants.NOTIFICATION_ID_FIELD);
+        String createdAtStr = asString(event, Constants.CREATED_AT_FIELD);
+        String subCategory = asString(event, Constants.SUB_CATEGORY_FIELD);
+
+        if (StringUtils.isAnyBlank(userId, notificationId, createdAtStr, subCategory)) {
+            log.warn("extractCleanupEvent: missing or blank required fields in event");
+            return null;
+        }
+
+        String actionTable = resolveActionTable(subCategory);
+        if (actionTable == null) {
+            log.warn("extractCleanupEvent: unrecognised subCategory='{}' notificationId={}", subCategory, notificationId);
+            return null;
+        }
+
+        if (isReviewTable(actionTable) && !isReviewStatusEligible(event, notificationId)) {
+            return null;
+        }
+
+        Instant createdAt = parseCreatedAt(createdAtStr, notificationId);
+        if (createdAt == null) {
+            return null;
+        }
+        return new CleanupEvent(userId, notificationId, createdAt, actionTable);
+    }
+
+    /**
+     * Returns {@code true} if the given table name is the peer-validation reviews table.
+     *
+     * @param actionTable the resolved Cassandra table name
+     * @return {@code true} for the reviews table, {@code false} otherwise
+     */
+    private boolean isReviewTable(String actionTable) {
+        return cbServerProperties.getCleanupTableReviews().equals(actionTable);
+    }
+
+    /**
+     * Checks whether the {@code status} field of a PEER_REVIEW_ASSIGNED event is in the
+     * configured list of statuses eligible for deletion.
+     *
+     * <p>PEER_EVALUATION_ASSIGNED events have no status field and therefore bypass this check.
+     *
+     * @param event          the parsed event map
+     * @param notificationId used in the warning log if the status is ineligible
+     * @return {@code true} if the status passes the eligibility check
+     */
+    private boolean isReviewStatusEligible(Map<String, Object> event, String notificationId) {
+        String status = asString(event, Constants.STATUS_FIELD);
+        List<String> allowedStatuses = cbServerProperties.getPeerReviewAssignedExcludedStatuses();
+        boolean eligible = status != null && allowedStatuses.stream().anyMatch(status::equalsIgnoreCase);
+        if (!eligible) {
+            log.warn("isReviewStatusEligible: status='{}' is not eligible for deletion notificationId={}",
+                    status, notificationId);
+        }
+        return eligible;
+    }
+
+    /**
+     * Parses the ISO-8601 {@code createdAt} string to an {@link Instant}.
+     * Returns {@code null} and logs a warning on parse failure.
+     *
+     * @param createdAtStr   the raw timestamp string
+     * @param notificationId used in the warning log if parsing fails
+     * @return the parsed {@link Instant}, or {@code null}
+     */
+    private Instant parseCreatedAt(String createdAtStr, String notificationId) {
+        try {
+            return Instant.parse(createdAtStr);
+        } catch (DateTimeParseException e) {
+            log.warn("parseCreatedAt: invalid createdAt='{}' notificationId={}", createdAtStr, notificationId);
+            return null;
+        }
+    }
+
+    /**
+     * Builds an audit record map for a successfully deleted event.
+     * The map is collected across all events in a chunk and flushed in bulk via
+     * {@link #bulkPersistAudit}.
+     *
+     * @param event   the event that was successfully deleted
+     * @param jobDate the cleanup job date for correlation
+     * @return the audit record ready for bulk insertion
+     */
+    private Map<String, Object> buildAuditRecord(CleanupEvent event, LocalDate jobDate) {
+        Map<String, Object> audit = new HashMap<>();
+        audit.put(Constants.USER_ID, event.userId());
+        audit.put(Constants.NOTIFICATION_ID, event.notificationId());
+        audit.put(Constants.FAILURE_REASON, cbServerProperties.getCleanupAuditDeletionPrefix() + event.actionTable());
+        audit.put(Constants.JOB_DATE, jobDate.toString());
+        return audit;
+    }
+
+    /**
+     * Inserts a batch of audit records into the cleanup audit table using a single
+     * {@code insertBulkRecord} call, replacing N individual inserts with one round-trip.
+     *
+     * <p>Any exception is swallowed with a WARN log so that an audit failure never
+     * interrupts the main cleanup loop.
+     *
+     * @param auditRecords non-empty list of audit maps to insert
+     */
+    private void bulkPersistAudit(List<Map<String, Object>> auditRecords) {
+        try {
+            String auditTable = resolveAuditTable();
+            cassandraOperation.insertBulkRecord(Constants.KEYSPACE_SUNBIRD, auditTable, auditRecords);
+            log.info("bulkPersistAudit: inserted {} audit records into {}", auditRecords.size(), auditTable);
+        } catch (Exception ex) {
+            log.warn("bulkPersistAudit: could not insert {} audit records: {}",
+                    auditRecords.size(), ex.getMessage());
+        }
+    }
+
+    /**
+     * Returns the audit table name from configuration.
+     *
+     * @return the audit table name
+     */
+    private String resolveAuditTable() {
+        return cbServerProperties.getCleanupTableAudit();
+    }
+
+    /**
+     * Deletes the action-table row using the {@code (user_id, notification_id)} primary key.
+     *
+     * @param event the cleanup event whose action row should be removed
+     */
+    private void deleteActionRecord(CleanupEvent event) {
+        cassandraOperation.deleteRecord(
+                Constants.KEYSPACE_SUNBIRD,
+                event.actionTable(),
+                Map.of(Constants.USER_ID, event.userId(), Constants.NOTIFICATION_ID, event.notificationId())
+        );
+    }
+
+    /**
+     * Maps a {@code subCategory} value to the corresponding Cassandra action table name.
+     * Uses a Java 17 switch expression for exhaustive, readable dispatch.
+     *
+     * @param subCategory the sub-category from the Kafka event (case-insensitive)
+     * @return the table name, or {@code null} for an unrecognised sub-category
+     */
+    private String resolveActionTable(String subCategory) {
+        if (subCategory == null) {
+            return null;
+        }
+        return switch (subCategory.toUpperCase(java.util.Locale.ROOT)) {
+            case Constants.SUB_CATEGORY_PEER_EVALUATION_ASSIGNED -> cbServerProperties.getCleanupTableRequests();
+            case Constants.SUB_CATEGORY_PEER_REVIEW_ASSIGNED -> cbServerProperties.getCleanupTableReviews();
+            default -> null;
+        };
+    }
+
+    /**
+     * Retrieves a field from a map as a {@code String} using Java 17 pattern matching.
+     * Returns {@code null} for absent or non-string values.
+     *
+     * @param map the event map
+     * @param key the field key
+     * @return the string value, or {@code null}
+     */
+    private static String asString(Map<String, Object> map, String key) {
+        return map.get(key) instanceof String s ? s : null;
+    }
+
+    /**
+     * Creates a standalone, manually-assigned {@link KafkaConsumer} for the cleanup job.
+     *
+     * <p>Auto-commit is disabled because offsets are never committed — the consumer is
+     * used purely for a one-shot time-windowed scan and is closed immediately after.
+     * Package-private to allow unit tests to substitute a mock via a Mockito spy.
+     *
+     * @return a configured, ready-to-use {@link KafkaConsumer}
+     */
+    KafkaConsumer<String, String> createKafkaConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cbServerProperties.getSpringKafkaBootStrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, cbServerProperties.getCleanupConsumerGroupId());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, String.valueOf(cbServerProperties.getCleanupBatchSize()));
+        return new KafkaConsumer<>(props);
+    }
+}

--- a/src/main/java/com/igot/cb/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbServerProperties.java
@@ -77,4 +77,43 @@ public class CbServerProperties {
 
   @Value("#{'${notification.list.peer.review.assigned.excluded.statuses}'.split(',')}")
   private List<String> peerReviewAssignedExcludedStatuses;
+
+  @Value("${cleanup.peer.validation.consumer.group.id}")
+  private String cleanupConsumerGroupId;
+
+  @Value("${cleanup.peer.validation.kafka.topics}")
+  private String cleanupKafkaTopics;
+
+  @Value("${cleanup.peer.validation.batch.size}")
+  private int cleanupBatchSize;
+
+  @Value("${cleanup.peer.validation.thread.pool.size}")
+  private int cleanupThreadPoolSize;
+
+  @Value("${cleanup.peer.validation.table.requests}")
+  private String cleanupTableRequests;
+
+  @Value("${cleanup.peer.validation.table.reviews}")
+  private String cleanupTableReviews;
+
+  @Value("${cleanup.peer.validation.table.audit}")
+  private String cleanupTableAudit;
+
+  @Value("${cleanup.peer.validation.window.start.time}")
+  private String cleanupWindowStartTime;
+
+  @Value("${cleanup.peer.validation.window.end.time}")
+  private String cleanupWindowEndTime;
+
+  @Value("${cleanup.peer.validation.day.offset}")
+  private long cleanupDayOffset;
+
+  @Value("${cleanup.peer.validation.poll.timeout.seconds}")
+  private int cleanupPollTimeoutSeconds;
+
+  @Value("${cleanup.peer.validation.executor.shutdown.timeout.minutes}")
+  private int cleanupExecutorShutdownTimeoutMinutes;
+
+  @Value("${cleanup.peer.validation.audit.deletion.prefix}")
+  private String cleanupAuditDeletionPrefix;
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -534,6 +534,13 @@ public class Constants {
     public static final String CATEGORY_PEER_VALIDATION = "PEER_VALIDATION";
     public static final String STATUS_EXPIRED = "EXPIRED";
 
+    // Peer Validation Cleanup Job
+    public static final String CLEANUP_PEER_VALIDATION_API_ID = "notification.v1.cleanup.peervalidation";
+    public static final String CLEANUP_PEER_VALIDATION_ENDPOINT = "/cleanup/peer-validations";
+    public static final String TABLE_PEER_VALIDATION_CLEANUP_FAILURES = "peer_validation_cleanup_failures";
+    public static final String JOB_DATE = "job_date";
+    public static final String FAILURE_REASON = "failure_reason";
+
     private Constants() {
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,7 +69,6 @@ sb.api.key=apiKey
 #Peer Validation Notification Configuration
 peervalidation.bulk.user.notification.limit=100
 peervalidation.notification.setting.check.enabled=false
-peervalidation.use.testing.tables=true
 peervalidation.list.max.fetch=100
 kafka.topic.process.peer.validation=dev.peer.validation.status.update
 kafka.group.process.peer.validation=dev.peer.validation.status.consumer.group
@@ -86,3 +85,27 @@ kafka.topic.notification.bulk.create.error=dev.notification.bulk.create.error
 # Status values to exclude from notification list API per subType
 notification.list.peer.evaluation.assigned.excluded.statuses=SUBMITTED,IGNORED
 notification.list.peer.review.assigned.excluded.statuses=APPROVED,REJECTED
+
+# Peer Validation Cleanup Job Configuration
+# Comma-separated list of Kafka topics to read from for cleanup
+cleanup.peer.validation.kafka.topics=dev.peer.validation.status.update,dev.peer.evaluation.status.update
+# Dedicated consumer group for the cleanup job (must be different from the main consumer groups)
+cleanup.peer.validation.consumer.group.id=peer-validation-cleanup-job
+# Number of (userId, notificationId) pairs to delete per Cassandra batch
+cleanup.peer.validation.batch.size=100
+cleanup.peer.validation.thread.pool.size=4
+# Cassandra table names for the cleanup job (change to *_testing to point at test tables)
+cleanup.peer.validation.table.requests=peer_validation_requests
+cleanup.peer.validation.table.reviews=peer_validation_reviews
+cleanup.peer.validation.table.audit=peer_validation_cleanup_failures
+# Kafka time-window bounds (HH:mm:ss, UTC) for the day being cleaned up
+cleanup.peer.validation.window.start.time=00:01:00
+cleanup.peer.validation.window.end.time=23:59:59
+# How many days before the job instant to target (1 = previous calendar day)
+cleanup.peer.validation.day.offset=1
+# Kafka poll timeout in seconds
+cleanup.peer.validation.poll.timeout.seconds=5
+# Executor shutdown grace-period in minutes
+cleanup.peer.validation.executor.shutdown.timeout.minutes=10
+# Prefix written into the audit failure_reason column for successfully deleted rows
+cleanup.peer.validation.audit.deletion.prefix=DELETED: 

--- a/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
@@ -613,6 +613,7 @@ class BulkPeerValidationNotificationTest {
             Map<String, Object> r = new HashMap<>();
             r.put(Constants.STATUS, status);
             r.put(Constants.CREATED_AT, createdAt);
+            r.put(Constants.SURVEY_END_DATE, createdAt.plusSeconds(86400));
             r.put(Constants.USER_ID, TEST_USER_ID);
             r.put(NOTIFICATION_ID, java.util.UUID.randomUUID().toString());
             return r;

--- a/src/test/java/com/igot/cb/peervalidationcleanup/service/PeerValidationCleanupServiceImplTest.java
+++ b/src/test/java/com/igot/cb/peervalidationcleanup/service/PeerValidationCleanupServiceImplTest.java
@@ -1,0 +1,469 @@
+package com.igot.cb.peervalidationcleanup.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.igot.cb.util.CbServerProperties;
+import com.igot.cb.util.Constants;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.igot.common.cassandra.CassandraOperation;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PeerValidationCleanupServiceImpl}.
+ *
+ * <p>Tests call {@code processCleanupEvents} directly (package-private) to validate
+ * Cassandra deletion logic independently of Kafka infrastructure. Kafka-level tests
+ * stub {@code createKafkaConsumer()} via a Mockito spy.
+ */
+@ExtendWith(MockitoExtension.class)
+class PeerValidationCleanupServiceImplTest {
+
+    @Mock
+    private CbServerProperties cbServerProperties;
+    @Mock
+    private CassandraOperation cassandraOperation;
+
+    private PeerValidationCleanupServiceImpl service;
+
+    private static final LocalDate TARGET_DATE = LocalDate.of(2024, 6, 1);
+    private static final String USER_ID = "user-001";
+    private static final String NOTIFICATION_ID = "notif-001";
+    private static final String CREATED_AT_ISO = "2024-06-01T10:00:00Z";
+    private static final String TOPIC = "test.topic";
+
+    @BeforeEach
+    void setUp() {
+        service = spy(new PeerValidationCleanupServiceImpl(cbServerProperties, cassandraOperation, new ObjectMapper()));
+        lenient().when(cbServerProperties.getPeerReviewAssignedExcludedStatuses())
+                .thenReturn(List.of(Constants.STATUS_APPROVED, Constants.STATUS_REJECTED));
+        lenient().when(cbServerProperties.getCleanupBatchSize()).thenReturn(100);
+        lenient().when(cbServerProperties.getCleanupThreadPoolSize()).thenReturn(2);
+        // Table names — match the production defaults so assertions against Constants still hold
+        lenient().when(cbServerProperties.getCleanupTableRequests())
+                .thenReturn(Constants.TABLE_PEER_VALIDATION_REQUESTS);
+        lenient().when(cbServerProperties.getCleanupTableReviews())
+                .thenReturn(Constants.TABLE_PEER_VALIDATION_REVIEWS);
+        lenient().when(cbServerProperties.getCleanupTableAudit())
+                .thenReturn(Constants.TABLE_PEER_VALIDATION_CLEANUP_FAILURES);
+        // Time-window and scheduling settings
+        lenient().when(cbServerProperties.getCleanupWindowStartTime()).thenReturn("00:01:00");
+        lenient().when(cbServerProperties.getCleanupWindowEndTime()).thenReturn("23:59:59");
+        lenient().when(cbServerProperties.getCleanupDayOffset()).thenReturn(1L);
+        lenient().when(cbServerProperties.getCleanupPollTimeoutSeconds()).thenReturn(5);
+        lenient().when(cbServerProperties.getCleanupExecutorShutdownTimeoutMinutes()).thenReturn(10);
+        lenient().when(cbServerProperties.getCleanupAuditDeletionPrefix()).thenReturn("DELETED: ");
+    }
+
+    @Nested
+    @DisplayName("processCleanupEvents – validation failures")
+    class ValidationFailures {
+
+        @Test
+        @DisplayName("empty list returns zero summary")
+        void emptyList_returnsZeroSummary() {
+            var summary = service.processCleanupEvents(List.of(), TARGET_DATE);
+            assertThat(summary.eligible()).isZero();
+            assertThat(summary.deleted()).isZero();
+            assertThat(summary.failed()).isZero();
+        }
+
+        @Test
+        @DisplayName("invalid JSON increments failed count but does not insert to Cassandra")
+        void invalidJson_incrementsFailedCount() {
+            var summary = service.processCleanupEvents(List.of("not-json{{{"), TARGET_DATE);
+            assertThat(summary.failed()).isEqualTo(1);
+            assertThat(summary.eligible()).isZero();
+            verify(cassandraOperation, never()).insertRecord(anyString(), anyString(), anyMap());
+        }
+
+        @Test
+        @DisplayName("missing userId increments failed count")
+        void missingUserId_incrementsFailed() {
+            String json = buildJson(null, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.failed()).isEqualTo(1);
+            assertThat(summary.eligible()).isZero();
+        }
+
+        @Test
+        @DisplayName("blank notificationId increments failed count")
+        void blankNotificationId_incrementsFailed() {
+            String json = buildJson(USER_ID, "  ", CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.failed()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("unknown subCategory increments failed count")
+        void unknownSubCategory_incrementsFailed() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "UNKNOWN_CATEGORY", Constants.STATUS_SUBMITTED);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.failed()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("invalid createdAt increments failed count")
+        void invalidCreatedAt_incrementsFailed() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, "not-a-date", "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.failed()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("PENDING status for PEER_REVIEW_ASSIGNED is not eligible for deletion")
+        void pendingStatus_peerReviewAssigned_notEligible() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO,
+                    "PEER_REVIEW_ASSIGNED", Constants.STATUS_PENDING);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.failed()).isEqualTo(1);
+            assertThat(summary.eligible()).isZero();
+            verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+        }
+
+        @Test
+        @DisplayName("SUBMITTED status for PEER_REVIEW_ASSIGNED is not eligible for deletion")
+        void submittedStatus_peerReviewAssigned_notEligible() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO,
+                    "PEER_REVIEW_ASSIGNED", Constants.STATUS_SUBMITTED);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.failed()).isEqualTo(1);
+            assertThat(summary.eligible()).isZero();
+            verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+        }
+
+        @Test
+        @DisplayName("null status for PEER_REVIEW_ASSIGNED is not eligible for deletion")
+        void nullStatus_peerReviewAssigned_notEligible() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_REVIEW_ASSIGNED", null);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.failed()).isEqualTo(1);
+            assertThat(summary.eligible()).isZero();
+            verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+        }
+    }
+
+    @Nested
+    @DisplayName("processCleanupEvents – successful deletions")
+    class SuccessfulDeletions {
+
+        @Test
+        @DisplayName("PEER_EVALUATION_ASSIGNED event deletes from requests table and notifications")
+        void peerEvaluationAssigned_deletesCorrectTables() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.eligible()).isEqualTo(1);
+            assertThat(summary.deleted()).isEqualTo(1);
+            assertThat(summary.failed()).isZero();
+            verify(cassandraOperation).deleteRecord(
+                    Constants.KEYSPACE_SUNBIRD,
+                    Constants.TABLE_PEER_VALIDATION_REQUESTS,
+                    Map.of(Constants.USER_ID, USER_ID, Constants.NOTIFICATION_ID, NOTIFICATION_ID)
+            );
+            verify(cassandraOperation, never()).deleteRecord(
+                    eq(Constants.KEYSPACE_SUNBIRD),
+                    eq(Constants.TABLE_USER_NOTIFICATION),
+                    anyMap()
+            );
+        }
+
+        @Test
+        @DisplayName("PEER_REVIEW_ASSIGNED event routes to reviews table")
+        void peerReviewAssigned_routesToReviewsTable() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_REVIEW_ASSIGNED", Constants.STATUS_APPROVED);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.deleted()).isEqualTo(1);
+            verify(cassandraOperation).deleteRecord(
+                    Constants.KEYSPACE_SUNBIRD,
+                    Constants.TABLE_PEER_VALIDATION_REVIEWS,
+                    Map.of(Constants.USER_ID, USER_ID, Constants.NOTIFICATION_ID, NOTIFICATION_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("REJECTED status for PEER_REVIEW_ASSIGNED is eligible for deletion")
+        void rejectedStatus_peerReviewAssigned_isEligibleForDeletion() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_REVIEW_ASSIGNED", Constants.STATUS_REJECTED);
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.deleted()).isEqualTo(1);
+            assertThat(summary.failed()).isZero();
+            verify(cassandraOperation).deleteRecord(
+                    eq(Constants.KEYSPACE_SUNBIRD),
+                    eq(Constants.TABLE_PEER_VALIDATION_REVIEWS),
+                    anyMap()
+            );
+        }
+
+        @Test
+        @DisplayName("multiple successful events produce a single bulk audit insert call")
+        void multipleSuccessful_bulkAuditCalledOnce() {
+            String eval = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            String review = buildJson("user-002", "notif-002", CREATED_AT_ISO, "PEER_REVIEW_ASSIGNED", Constants.STATUS_APPROVED);
+            service.processCleanupEvents(List.of(eval, review), TARGET_DATE);
+            verify(cassandraOperation, times(1)).insertBulkRecord(
+                    eq(Constants.KEYSPACE_SUNBIRD),
+                    eq(Constants.TABLE_PEER_VALIDATION_CLEANUP_FAILURES),
+                    anyList()
+            );
+        }
+
+        @Test
+        @DisplayName("subCategory matching is case-insensitive")
+        void subCategory_caseInsensitiveMatch() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "peer_evaluation_assigned", Constants.STATUS_SUBMITTED);
+
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+
+            assertThat(summary.deleted()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("successful deletion inserts a bulk audit record into the cleanup audit table")
+        void successfulDelete_insertsBulkAuditRecord() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            service.processCleanupEvents(List.of(json), TARGET_DATE);
+            verify(cassandraOperation, times(1)).insertBulkRecord(
+                    eq(Constants.KEYSPACE_SUNBIRD),
+                    eq(Constants.TABLE_PEER_VALIDATION_CLEANUP_FAILURES),
+                    anyList()
+            );
+        }
+
+        @Test
+        @DisplayName("multiple events produce correct aggregate counts")
+        void multipleEvents_correctCounts() {
+            String valid1 = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            String valid2 = buildJson("user-002", "notif-002", CREATED_AT_ISO, "PEER_REVIEW_ASSIGNED", Constants.STATUS_APPROVED);
+            String invalid = "bad-json";
+
+            var summary = service.processCleanupEvents(List.of(valid1, valid2, invalid), TARGET_DATE);
+
+            assertThat(summary.eligible()).isEqualTo(2);
+            assertThat(summary.deleted()).isEqualTo(2);
+            assertThat(summary.failed()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("processCleanupEvents – Cassandra errors")
+    class CassandraErrors {
+
+        @Test
+        @DisplayName("Cassandra deleteRecord throws increments failed count and skips audit insert")
+        void cassandraThrows_incrementsFailedCountAndSkipsAudit() {
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            doThrow(new RuntimeException("Cassandra unavailable"))
+                    .when(cassandraOperation).deleteRecord(anyString(), anyString(), anyMap());
+            var summary = service.processCleanupEvents(List.of(json), TARGET_DATE);
+            assertThat(summary.eligible()).isEqualTo(1);
+            assertThat(summary.failed()).isEqualTo(1);
+            assertThat(summary.deleted()).isZero();
+            verify(cassandraOperation, never()).insertBulkRecord(anyString(), anyString(), anyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("runCleanup – orchestration")
+    class RunCleanup {
+
+        @Mock
+        private KafkaConsumer<String, String> mockConsumer;
+
+        private PeerValidationCleanupServiceImpl kafkaService;
+
+        @BeforeEach
+        void setUpKafkaService() {
+            kafkaService = spy(new PeerValidationCleanupServiceImpl(
+                    cbServerProperties, cassandraOperation, new ObjectMapper()));
+            doReturn(mockConsumer).when(kafkaService).createKafkaConsumer();
+        }
+
+        @AfterEach
+        void closeMockConsumer() {
+            mockConsumer.close();
+        }
+
+        @Test
+        @DisplayName("no partitions for topic → zero events processed, no Cassandra calls")
+        void noPartitions_zeroEvents() {
+            when(cbServerProperties.getCleanupKafkaTopics()).thenReturn(TOPIC);
+            when(mockConsumer.partitionsFor(TOPIC)).thenReturn(Collections.emptyList());
+            kafkaService.runCleanup(Instant.now());
+            verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+        }
+
+        @Test
+        @DisplayName("consumer returns empty poll → no Cassandra calls")
+        void emptyPoll_noCassandraCalls() {
+            TopicPartition tp = new TopicPartition(TOPIC, 0);
+            PartitionInfo pi = new PartitionInfo(TOPIC, 0, null, null, null);
+            when(cbServerProperties.getCleanupKafkaTopics()).thenReturn(TOPIC);
+            when(mockConsumer.partitionsFor(TOPIC)).thenReturn(List.of(pi));
+            when(mockConsumer.offsetsForTimes(anyMap()))
+                    .thenReturn(Map.of(tp, new OffsetAndTimestamp(0L, 0L)));
+            when(mockConsumer.endOffsets(anyList())).thenReturn(Map.of(tp, 0L));
+            kafkaService.runCleanup(Instant.now());
+            verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+        }
+
+        @Test
+        @DisplayName("single valid event in window → one Cassandra delete pair")
+        void singleEventInWindow_deletesCassandraRows() {
+            TopicPartition tp = new TopicPartition(TOPIC, 0);
+            PartitionInfo pi = new PartitionInfo(TOPIC, 0, null, null, null);
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            LocalDate yesterday = LocalDate.now(ZoneOffset.UTC).minusDays(1);
+            long windowStartMs = yesterday.atTime(0, 1, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+            long windowEndMs = yesterday.atTime(23, 59, 59).toInstant(ZoneOffset.UTC).toEpochMilli();
+            long midpointMs = (windowStartMs + windowEndMs) / 2;
+            ConsumerRecord<String, String> kafkaRecord =
+                    new ConsumerRecord<>(TOPIC, 0, 0L, midpointMs,
+                            TimestampType.CREATE_TIME, -1L, -1, -1, null, json);
+            ConsumerRecords<String, String> batch =
+                    new ConsumerRecords<>(Map.of(tp, List.of(kafkaRecord)));
+            when(cbServerProperties.getCleanupKafkaTopics()).thenReturn(TOPIC);
+            when(mockConsumer.partitionsFor(TOPIC)).thenReturn(List.of(pi));
+            when(mockConsumer.offsetsForTimes(anyMap()))
+                    .thenReturn(Map.of(tp, new OffsetAndTimestamp(0L, windowStartMs)));
+            when(mockConsumer.endOffsets(anyList())).thenReturn(Map.of(tp, 2L));
+            doReturn(batch).doReturn(ConsumerRecords.<String, String>empty()).when(mockConsumer).poll(any(Duration.class));
+            kafkaService.runCleanup(Instant.now());
+            verify(cassandraOperation, times(1)).deleteRecord(
+                    eq(Constants.KEYSPACE_SUNBIRD),
+                    eq(Constants.TABLE_PEER_VALIDATION_REQUESTS),
+                    anyMap()
+            );
+            verify(cassandraOperation, never()).deleteRecord(
+                    eq(Constants.KEYSPACE_SUNBIRD),
+                    eq(Constants.TABLE_USER_NOTIFICATION),
+                    anyMap()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("parseTopics – configuration edge cases (via runCleanup)")
+    class ParseTopics {
+
+        @Mock
+        private KafkaConsumer<String, String> mockConsumer;
+
+        private PeerValidationCleanupServiceImpl kafkaService;
+
+        @BeforeEach
+        void setUpKafkaService() {
+            kafkaService = spy(new PeerValidationCleanupServiceImpl(
+                    cbServerProperties, cassandraOperation, new ObjectMapper()));
+            doReturn(mockConsumer).when(kafkaService).createKafkaConsumer();
+        }
+
+        @AfterEach
+        void closeMockConsumer() {
+            mockConsumer.close();
+        }
+
+        @Test
+        @DisplayName("topics with blank entries are filtered out")
+        void blankTopicEntries_filtered() {
+            when(cbServerProperties.getCleanupKafkaTopics()).thenReturn("topic-a,,  ,topic-b");
+            when(mockConsumer.partitionsFor("topic-a")).thenReturn(Collections.emptyList());
+            when(mockConsumer.partitionsFor("topic-b")).thenReturn(Collections.emptyList());
+            kafkaService.runCleanup(Instant.now());
+            verify(mockConsumer).partitionsFor("topic-a");
+            verify(mockConsumer).partitionsFor("topic-b");
+        }
+    }
+
+    @Nested
+    @DisplayName("processRecord – window boundary decisions")
+    class ProcessRecord {
+
+        @Mock
+        private KafkaConsumer<String, String> mockConsumer;
+
+        private PeerValidationCleanupServiceImpl kafkaService;
+
+        @BeforeEach
+        void setUpKafkaService() {
+            kafkaService = spy(new PeerValidationCleanupServiceImpl(
+                    cbServerProperties, cassandraOperation, new ObjectMapper()));
+            doReturn(mockConsumer).when(kafkaService).createKafkaConsumer();
+        }
+
+        @AfterEach
+        void closeMockConsumer() {
+            mockConsumer.close();
+        }
+
+        @Test
+        @DisplayName("record after window end marks partition exhausted, not collected")
+        void recordAfterWindowEnd_exhausted_notCollected() {
+            TopicPartition tp = new TopicPartition(TOPIC, 0);
+            PartitionInfo pi = new PartitionInfo(TOPIC, 0, null, null, null);
+            LocalDate yesterday = LocalDate.now(ZoneOffset.UTC).minusDays(1);
+            long windowEndMs = yesterday.atTime(23, 59, 59).toInstant(ZoneOffset.UTC).toEpochMilli();
+            long afterWindowMs = windowEndMs + 10_000;
+            String json = buildJson(USER_ID, NOTIFICATION_ID, CREATED_AT_ISO, "PEER_EVALUATION_ASSIGNED", Constants.STATUS_SUBMITTED);
+            ConsumerRecord<String, String> lateRecord =
+                    new ConsumerRecord<>(TOPIC, 0, 0L, afterWindowMs,
+                            TimestampType.CREATE_TIME, -1L, -1, -1, null, json);
+            ConsumerRecords<String, String> batch =
+                    new ConsumerRecords<>(Map.of(tp, List.of(lateRecord)));
+            when(cbServerProperties.getCleanupKafkaTopics()).thenReturn(TOPIC);
+            when(mockConsumer.partitionsFor(TOPIC)).thenReturn(List.of(pi));
+            long windowStartMs = yesterday.atTime(0, 1, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+            when(mockConsumer.offsetsForTimes(anyMap()))
+                    .thenReturn(Map.of(tp, new OffsetAndTimestamp(0L, windowStartMs)));
+            when(mockConsumer.endOffsets(anyList())).thenReturn(Map.of(tp, 5L));
+            doReturn(batch).doReturn(ConsumerRecords.<String, String>empty()).when(mockConsumer).poll(any(Duration.class));
+            kafkaService.runCleanup(Instant.now());
+            verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+        }
+    }
+
+    private String buildJson(String userId, String notificationId, String createdAt,
+                             String subCategory, String status) {
+        Map<String, Object> map = new HashMap<>();
+        if (userId != null) map.put(Constants.USER_ID_FIELD, userId);
+        if (notificationId != null) map.put(Constants.NOTIFICATION_ID_FIELD, notificationId);
+        if (createdAt != null) map.put(Constants.CREATED_AT_FIELD, createdAt);
+        if (subCategory != null) map.put(Constants.SUB_CATEGORY_FIELD, subCategory);
+        if (status != null) map.put(Constants.STATUS_FIELD, status);
+        try {
+            return new ObjectMapper().writeValueAsString(map);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
- Introduce PeerValidationCleanupServiceImpl for time-windowed Kafka reads and Cassandra deletion of stale peer validation records and updates the audit table.
- Extend CbServerProperties and Constants with cleanup config and table names