### PR TITLE
Fix: handle String to Instant conversion in handleNonPeerValidationRead

### DIFF
--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -2104,7 +2104,10 @@ public class NotificationServiceImpl implements NotificationService {
     private ApiResponse handleNonPeerValidationRead(String userId, Map<String, Object> notification, 
             Map<String, Object> request, ApiResponse response) {
         String notificationId = (String) notification.get(NOTIFICATION_ID);
-        Instant createdAt = (Instant) request.get(CREATED_AT);
+        Object createdAtRaw = request.get(CREATED_AT);
+        Instant createdAt = (createdAtRaw instanceof Instant instant)
+                ? instant
+                : Instant.parse((String) createdAtRaw);
         Instant now = Instant.now();
         cassandraOperation.updateRecord(
                 KEYSPACE_SUNBIRD,


### PR DESCRIPTION
The `created_at` field from the JSON request arrives as a String (ISO-8601 format) but was being directly cast to Instant, causing:
  java.lang.ClassCastException: class java.lang.String cannot be cast to class java.time.Instant

Now handles both Instant and String types, consistent with the pattern already used in markIndividualNotificationAsRead method.