### PR TITLE
KB-13018 | Peer verification request not removed from Incoming Reques…

### DIFF
--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -1861,7 +1861,7 @@ public class NotificationServiceImpl implements NotificationService {
                 ? instant
                 : Instant.parse((String) createdAtRaw);
         if (StringUtils.isNotBlank((String) request.get(STATUS))) {
-            handleStatusBasedAction(userId, notificationId, createdAt, now, (String) request.get(STATUS));
+            handleStatusBasedAction(userId, notificationId, createdAt, now, (String) request.get(STATUS), (String) notification.get(SUB_CATEGORY));
         } else {
             if (Boolean.TRUE.equals(notification.get(READ))) {
                 log.info("Notification already read: userId={}, notificationId={}", userId, notificationId);
@@ -2042,18 +2042,28 @@ public class NotificationServiceImpl implements NotificationService {
 
     /**
      * Handles status-based actions (e.g., NO, SKIP_FOR_NOW) by updating both tables.
+     * Routes to {@code peer_validation_requests} for PEER_EVALUATION_ASSIGNED
+     * or {@code peer_validation_reviews} for PEER_REVIEW_ASSIGNED.
      *
      * @param userId         the user ID
      * @param notificationId the notification ID
      * @param createdAt      the notification's created_at timestamp
      * @param now            the current timestamp
      * @param status         the status to set (e.g., NO, SKIP_FOR_NOW)
+     * @param subCategory    the sub_category of the notification
      */
-    private void handleStatusBasedAction(String userId, String notificationId, 
-            Instant createdAt, Instant now, String status) {
+    private void handleStatusBasedAction(String userId, String notificationId,
+            Instant createdAt, Instant now, String status, String subCategory) {
         updateUserNotificationWithStatus(userId, createdAt, now, status);
-        updatePeerValidationRequestWithStatus(userId, notificationId, now, status);
-        log.info("Status updated: userId={}, notificationId={}, status={}", userId, notificationId, status);
+        if (SUB_CATEGORY_PEER_REVIEW_ASSIGNED.equalsIgnoreCase(subCategory)) {
+            log.info("Updating peer_validation_reviews for userId={}, notificationId={}, status={}", userId, notificationId, status);
+            updatePeerValidationReviewWithStatus(userId, notificationId, now, status);
+        } else if (SUB_CATEGORY_PEER_EVALUATION_ASSIGNED.equalsIgnoreCase(subCategory)) {
+            log.info("Updating peer_validation_requests for userId={}, notificationId={}, status={}", userId, notificationId, status);
+            updatePeerValidationRequestWithStatus(userId, notificationId, now, status);
+        }
+        log.info("Status updated: userId={}, notificationId={}, status={}, subCategory={}",
+                userId, notificationId, status, subCategory);
     }
 
     /**
@@ -2394,4 +2404,16 @@ public class NotificationServiceImpl implements NotificationService {
         }
     }
 
+
+    /**
+     * Updates the peer_validation_reviews table with status and action timestamp.
+     */
+    private void updatePeerValidationReviewWithStatus(String userId, String notificationId, Instant now, String status) {
+        cassandraOperation.updateRecord(
+                KEYSPACE_SUNBIRD,
+                TABLE_PEER_VALIDATION_REVIEWS,
+                Map.of(STATUS, status, UPDATED_AT, now),
+                Map.of(USER_ID, userId, NOTIFICATION_ID, notificationId)
+        );
+    }
 }

--- a/src/test/java/com/igot/cb/notification/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/NotificationServiceImplTest.java
@@ -2588,8 +2588,8 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void testHandleStatusBasedAction_UpdatesBothTables() throws Exception {
-        Method method = NotificationServiceImpl.class.getDeclaredMethod("handleStatusBasedAction", String.class, String.class, Instant.class, Instant.class, String.class);
+    void testHandleStatusBasedAction_UpdatesBothTables_EvaluationAssigned() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("handleStatusBasedAction", String.class, String.class, Instant.class, Instant.class, String.class, String.class);
         method.setAccessible(true);
         String userId = "user-123";
         String notificationId = "notif-456";
@@ -2598,7 +2598,7 @@ class NotificationServiceImplTest {
         String status = "SKIP_FOR_NOW";
         when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
                 .thenReturn(Map.of(RESPONSE, Constants.SUCCESS));
-        method.invoke(notificationService, userId, notificationId, createdAt, now, status);
+        method.invoke(notificationService, userId, notificationId, createdAt, now, status, Constants.SUB_CATEGORY_PEER_EVALUATION_ASSIGNED);
         verify(cassandraOperation, times(1)).updateRecord(
                 eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
                 argThat(map -> status.equals(map.get(STATUS)) && Boolean.TRUE.equals(map.get("read"))),
@@ -2606,6 +2606,30 @@ class NotificationServiceImplTest {
         );
         verify(cassandraOperation, times(1)).updateRecord(
                 eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REQUESTS),
+                argThat(map -> status.equals(map.get(STATUS))),
+                eq(Map.of(USER_ID, userId, NOTIFICATION_ID, notificationId))
+        );
+    }
+
+    @Test
+    void testHandleStatusBasedAction_UpdatesBothTables_ReviewAssigned() throws Exception {
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("handleStatusBasedAction", String.class, String.class, Instant.class, Instant.class, String.class, String.class);
+        method.setAccessible(true);
+        String userId = "user-123";
+        String notificationId = "notif-456";
+        Instant createdAt = Instant.parse("2026-03-15T10:00:00Z");
+        Instant now = Instant.now();
+        String status = "SKIP_FOR_NOW";
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(RESPONSE, Constants.SUCCESS));
+        method.invoke(notificationService, userId, notificationId, createdAt, now, status, Constants.SUB_CATEGORY_PEER_REVIEW_ASSIGNED);
+        verify(cassandraOperation, times(1)).updateRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
+                argThat(map -> status.equals(map.get(STATUS)) && Boolean.TRUE.equals(map.get("read"))),
+                eq(Map.of(USER_ID, userId, CREATED_AT, createdAt))
+        );
+        verify(cassandraOperation, times(1)).updateRecord(
+                eq(KEYSPACE_SUNBIRD), eq(TABLE_PEER_VALIDATION_REVIEWS),
                 argThat(map -> status.equals(map.get(STATUS))),
                 eq(Map.of(USER_ID, userId, NOTIFICATION_ID, notificationId))
         );


### PR DESCRIPTION
…ts after clicking 'No' (#102)

1.fix: route peer validation status updates to correct table by sub_category 2.PEER_REVIEW_ASSIGNED now updates peer_validation_reviews and PEER_EVALUATION_ASSIGNED updates peer_validation_requests. Updated tests to cover both routing paths.