### PR TITLE
fix: skip survey participant count -  Kafka event for PEER_REVIEW_ASSIGNED notifications

### DIFF
--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -1867,7 +1867,7 @@ public class NotificationServiceImpl implements NotificationService {
                 log.info("Notification already read: userId={}, notificationId={}", userId, notificationId);
                 return buildAlreadyReadResponse(response, notificationId);
             }
-            handleNormalReadFlow(userId, notificationId, createdAt, now);
+            handleNormalReadFlow(userId, notificationId, createdAt, now, (String) notification.get(SUB_CATEGORY));
         }
         log.info("Notification marked as read: userId={}, notificationId={}", userId, notificationId);
         return buildReadSuccessResponse(response, notificationId, now);
@@ -2098,8 +2098,12 @@ public class NotificationServiceImpl implements NotificationService {
      * @param createdAt      the notification's created_at timestamp
      * @param now            the current timestamp
      */
-    private void handleNormalReadFlow(String userId, String notificationId, Instant createdAt, Instant now) {
+    private void handleNormalReadFlow(String userId, String notificationId, Instant createdAt, Instant now, String subCategory) {
         updateNotificationReadStatus(userId, createdAt, now);
+        if (!SUB_CATEGORY_PEER_EVALUATION_ASSIGNED.equalsIgnoreCase(subCategory)) {
+            log.info("publishPeerSurveyReadEvent: skipping for subCategory={}, notificationId={}", subCategory, notificationId);
+            return;
+        }
         publishPeerSurveyReadEvent(userId, notificationId, createdAt, now);
     }
 

--- a/src/test/java/com/igot/cb/notification/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/NotificationServiceImplTest.java
@@ -2637,7 +2637,7 @@ class NotificationServiceImplTest {
 
     @Test
     void testHandleNormalReadFlow_UpdatesReadStatusAndPublishesEvent() throws Exception {
-        Method method = NotificationServiceImpl.class.getDeclaredMethod("handleNormalReadFlow", String.class, String.class, Instant.class, Instant.class);
+        Method method = NotificationServiceImpl.class.getDeclaredMethod("handleNormalReadFlow", String.class, String.class, Instant.class, Instant.class, String.class);
         method.setAccessible(true);
         String userId = "user-123";
         String notificationId = "notif-456";
@@ -2648,7 +2648,7 @@ class NotificationServiceImplTest {
         when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList(), anyInt()))
                 .thenReturn(List.of(Map.of("message", "{\"data\":[{\"formId\":\"form-123\"}]}")));
         when(cbServerProperties.getKafkaTopicNotificationReadEvent()).thenReturn("test-topic");
-        method.invoke(notificationService, userId, notificationId, createdAt, now);
+        method.invoke(notificationService, userId, notificationId, createdAt, now, SUB_CATEGORY_PEER_EVALUATION_ASSIGNED);
         verify(cassandraOperation, times(1)).updateRecord(
                 eq(KEYSPACE_SUNBIRD), eq(TABLE_USER_NOTIFICATION),
                 argThat(map -> Boolean.TRUE.equals(map.get("read"))),


### PR DESCRIPTION

When a peer-validation notification is marked as read, a Kafka event is published to the forms service to increment the survey participant/response count.

This event should only fire for PEER_EVALUATION_ASSIGNED (the learner taking the survey), not for PEER_REVIEW_ASSIGNED (the reviewer reviewing submissions). Previously, the event was being triggered for both sub-categories.