### PR TITLE
KB-13789 | KB-13020 | 'Start Survey' button is enabled for ENDED surveys in Pending Survey tab

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>

--- a/src/main/java/com/igot/cb/elasticsearch/config/EsClientConfig.java
+++ b/src/main/java/com/igot/cb/elasticsearch/config/EsClientConfig.java
@@ -16,12 +16,13 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import java.util.Arrays;
 
 @Configuration
 public class EsClientConfig {
 
-    @Value("${elasticsearch.host}")
-    private String elasticsearchHost;
+    @Value("${elasticsearch.hosts}")
+    private String elasticsearchHosts;
 
     @Value("${elasticsearch.port}")
     private int elasticsearchPort;
@@ -38,8 +39,12 @@ public class EsClientConfig {
         credentialsProvider.setCredentials(AuthScope.ANY,
                 new UsernamePasswordCredentials(elasticsearchUsername, elasticsearchPassword));
 
-        RestClientBuilder builder = RestClient.builder(
-                        new HttpHost(elasticsearchHost, elasticsearchPort, Constants.ES_HTTP_SCHEME))
+        HttpHost[] httpHosts = Arrays.stream(elasticsearchHosts.split(","))
+                .map(String::trim)
+                .map(host -> new HttpHost(host, elasticsearchPort, Constants.ES_HTTP_SCHEME))
+                .toArray(HttpHost[]::new);
+
+        RestClientBuilder builder = RestClient.builder(httpHosts)
                 .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider).addInterceptorLast((HttpResponseInterceptor) (response, context) ->
                         response.addHeader(Constants.ES_PRODUCT_HEADER, Constants.ES_PRODUCT_HEADER_VALUE)))
                 .setDefaultHeaders(new org.apache.http.Header[]{

--- a/src/main/java/com/igot/cb/elasticsearch/config/EsClientConfig.java
+++ b/src/main/java/com/igot/cb/elasticsearch/config/EsClientConfig.java
@@ -1,0 +1,53 @@
+package com.igot.cb.elasticsearch.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.igot.cb.util.Constants;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EsClientConfig {
+
+    @Value("${elasticsearch.host}")
+    private String elasticsearchHost;
+
+    @Value("${elasticsearch.port}")
+    private int elasticsearchPort;
+
+    @Value("${elasticsearch.username}")
+    private String elasticsearchUsername;
+
+    @Value("${elasticsearch.password}")
+    private String elasticsearchPassword;
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY,
+                new UsernamePasswordCredentials(elasticsearchUsername, elasticsearchPassword));
+
+        RestClientBuilder builder = RestClient.builder(
+                        new HttpHost(elasticsearchHost, elasticsearchPort, Constants.ES_HTTP_SCHEME))
+                .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider).addInterceptorLast((HttpResponseInterceptor) (response, context) ->
+                        response.addHeader(Constants.ES_PRODUCT_HEADER, Constants.ES_PRODUCT_HEADER_VALUE)))
+                .setDefaultHeaders(new org.apache.http.Header[]{
+                        new org.apache.http.message.BasicHeader(Constants.CONTENT_TYPE, Constants.APPLICATION_JSON),
+                        new org.apache.http.message.BasicHeader(Constants.ES_PRODUCT_HEADER, Constants.ES_PRODUCT_HEADER_VALUE)});
+        RestClient restClient = builder.build();
+        ElasticsearchTransport elasticsearchTransport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        return new ElasticsearchClient(elasticsearchTransport);
+    }
+
+}

--- a/src/main/java/com/igot/cb/elasticsearch/service/EsClientService.java
+++ b/src/main/java/com/igot/cb/elasticsearch/service/EsClientService.java
@@ -1,0 +1,11 @@
+package com.igot.cb.elasticsearch.service;
+
+import java.util.List;
+import java.util.Map;
+
+
+public interface EsClientService {
+
+  /** Bool-filter terms query; optionally narrows by {@code contextType}; projects only requested {@code fields}. Never returns {@code null}. */
+  List<Map<String, Object>> searchByTerms(String esIndexName, String fieldName, List<String> values, String contextType, List<String> fields);
+}

--- a/src/main/java/com/igot/cb/elasticsearch/service/EsClientServiceImpl.java
+++ b/src/main/java/com/igot/cb/elasticsearch/service/EsClientServiceImpl.java
@@ -1,0 +1,114 @@
+package com.igot.cb.elasticsearch.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.igot.cb.util.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Default {@link EsClientService} backed by the Elasticsearch Java client (8.x).
+ * Uses bool-filter queries for score-free, cache-friendly lookups.
+ */
+@Service
+@Slf4j
+public class EsClientServiceImpl implements EsClientService {
+
+    private static final Class<Map<String, Object>> SOURCE_TYPE =
+            (Class<Map<String, Object>>) (Class<?>) Map.class;
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    @Value("${es.max.terms.count}")
+    private int maxTermsCount;
+
+    @Value("${es.query.timeout}")
+    private String queryTimeout;
+
+    public EsClientServiceImpl(ElasticsearchClient elasticsearchClient) {
+        this.elasticsearchClient = elasticsearchClient;
+    }
+
+    /** Bool-filter terms query on {@code fieldName}; optionally narrows by {@code contextType}; projects only requested {@code fields}. */
+    @Override
+    public List<Map<String, Object>> searchByTerms(
+            String esIndexName, String fieldName, List<String> values,
+            String contextType, List<String> fields) {
+        if (!isValidInput(esIndexName, fieldName, values)) {
+            log.debug("searchByTerms skipped — invalid input: index='{}', field='{}', valueCount={}",
+                    esIndexName, fieldName, CollectionUtils.isEmpty(values) ? 0 : values.size());
+            return Collections.emptyList();
+        }
+        if (values.size() > maxTermsCount) {
+            log.error("searchByTerms aborted — {} value(s) exceeds ES max terms limit of {}", values.size(), maxTermsCount);
+            return Collections.emptyList();
+        }
+        try {
+            SearchRequest request = buildSearchRequest(esIndexName, fieldName, values, contextType, fields);
+            List<Map<String, Object>> results = extractSources(elasticsearchClient.search(request, SOURCE_TYPE));
+            log.info("searchByTerms: index='{}', field='{}', queried={}, returned={}",
+                    esIndexName, fieldName, values.size(), results.size());
+            return results;
+        } catch (IOException e) {
+            log.error("searchByTerms failed — index='{}', field='{}': {}", esIndexName, fieldName, e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /** Returns {@code true} only when index, field, and values are all non-null and non-empty. */
+    private boolean isValidInput(String esIndexName, String fieldName, List<String> values) {
+        return StringUtils.isNotBlank(esIndexName)
+                && StringUtils.isNotBlank(fieldName)
+                && CollectionUtils.isNotEmpty(values);
+    }
+
+    /** Builds a bool-filter {@link SearchRequest} with size, timeout, terms clause, optional contextType clause, and source field projection. */
+    private SearchRequest buildSearchRequest(
+            String esIndexName, String fieldName, List<String> values,
+            String contextType, List<String> fields) {
+        return SearchRequest.of(b -> {
+            b.index(esIndexName)
+             .size(values.size())
+             .timeout(queryTimeout)
+             .query(q -> q.bool(bool -> {
+                bool.filter(f -> f.terms(t -> t.field(fieldName)
+                        .terms(tv -> tv.value(toFieldValues(values)))));
+                if (StringUtils.isNotBlank(contextType)) {
+                    bool.filter(f -> f.term(t -> t.field(Constants.CONTEXT_TYPE).value(contextType)));
+                }
+                return bool;
+            }));
+            if (CollectionUtils.isNotEmpty(fields)) {
+                b.source(s -> s.filter(f -> f.includes(fields)));
+            }
+            return b;
+        });
+    }
+
+    /** Converts plain strings to {@link FieldValue} instances required by the ES terms query API. */
+    private List<FieldValue> toFieldValues(List<String> values) {
+        return values.stream().map(FieldValue::of).toList();
+    }
+
+    /** Extracts non-null source maps from all hits in the search response. */
+    private List<Map<String, Object>> extractSources(
+            SearchResponse<Map<String, Object>> response) {
+        return response.hits().hits().stream()
+                .map(Hit::source)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+}
+

--- a/src/main/java/com/igot/cb/notification/service/FormExpiryValidator.java
+++ b/src/main/java/com/igot/cb/notification/service/FormExpiryValidator.java
@@ -1,0 +1,12 @@
+package com.igot.cb.notification.service;
+
+import java.util.List;
+import java.util.Map;
+
+/** Marks PENDING notification records as EXPIRED when their form's {@code endDate} has passed, using ES as the authoritative source. */
+public interface FormExpiryValidator {
+
+  /** Mutates status to EXPIRED in-place for any PENDING record whose form endDate is past; returns the same list reference, never {@code null}. */
+  List<Map<String, Object>> validateAndMarkExpired(List<Map<String, Object>> records);
+
+}

--- a/src/main/java/com/igot/cb/notification/service/impl/FormExpiryValidatorImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/FormExpiryValidatorImpl.java
@@ -1,0 +1,207 @@
+package com.igot.cb.notification.service.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.igot.cb.elasticsearch.service.EsClientService;
+import com.igot.cb.notification.service.FormExpiryValidator;
+import com.igot.cb.transactional.caffeinecache.NotificationMetadataCacheManager;
+import com.igot.cb.util.CbServerProperties;
+import com.igot.cb.util.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Drives a PENDING → EXPIRED state transition for notification records whose form has passed its
+ * {@code endDate}. Processes in configurable batches with Caffeine cache-first ES lookups.
+ */
+
+@Service
+@Slf4j
+public class FormExpiryValidatorImpl implements FormExpiryValidator {
+
+    private final EsClientService esClientService;
+    private final CbServerProperties cbServerProperties;
+    private final ObjectMapper objectMapper;
+    private final NotificationMetadataCacheManager cacheManager;
+
+    public FormExpiryValidatorImpl(EsClientService esClientService,
+                                   CbServerProperties cbServerProperties,
+                                   ObjectMapper objectMapper,
+                                   NotificationMetadataCacheManager cacheManager) {
+        this.esClientService = esClientService;
+        this.cbServerProperties = cbServerProperties;
+        this.objectMapper = objectMapper;
+        this.cacheManager = cacheManager;
+    }
+
+    /** Filters to PENDING records, processes in fixed-size batches, and returns the original list with statuses applied in-place. */
+    @Override
+    public List<Map<String, Object>> validateAndMarkExpired(List<Map<String, Object>> records) {
+        if (CollectionUtils.isEmpty(records)) {
+            return Collections.emptyList();
+        }
+        List<Map<String, Object>> pendingRecords = filterPendingRecords(records);
+        if (CollectionUtils.isEmpty(pendingRecords)) {
+            log.info("No PENDING records found among {} total — skipping expiry check", records.size());
+            return records;
+        }
+        int batchSize = cbServerProperties.getFormsEsFetchBatchSize();
+        log.info("Starting expiry validation: {} PENDING record(s) out of {} total, batch size {}",
+                pendingRecords.size(), records.size(), batchSize);
+        for (int i = 0; i < pendingRecords.size(); i += batchSize) {
+            List<Map<String, Object>> batch = pendingRecords.subList(i, Math.min(i + batchSize, pendingRecords.size()));
+            processBatch(batch);
+        }
+        log.info("Expiry validation complete for {} PENDING record(s)", pendingRecords.size());
+        return records;
+    }
+
+    /** Indexes batch by formId, resolves endDates via cache/ES, then marks expired records. Short-circuits if no valid formId found. */
+    private void processBatch(List<Map<String, Object>> batch) {
+        Map<String, List<Map<String, Object>>> formIdToRecords = buildFormIdToRecordMap(batch);
+        if (formIdToRecords.isEmpty()) {
+            log.debug("Batch of {} record(s) has no extractable formIds — skipping", batch.size());
+            return;
+        }
+        log.info("Processing batch: {} record(s), {} unique formId(s)", batch.size(), formIdToRecords.size());
+        List<String> formIds = List.copyOf(formIdToRecords.keySet());
+        Map<String, Long> formIdToEndDate = resolveEndDates(formIds);
+        markExpiredRecords(formIdToRecords, formIdToEndDate);
+    }
+
+    /** Parses each notification's metadata once and groups all notifications by formId; drops entries with invalid or missing formIds. */
+    private Map<String, List<Map<String, Object>>> buildFormIdToRecordMap(List<Map<String, Object>> batch) {
+        return batch.stream()
+                .flatMap(notification -> Optional.ofNullable(extractFormId(notification))
+                        .filter(id -> !id.isBlank())
+                        .map(id -> Map.entry(id, notification))
+                        .stream())
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getKey,
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())
+                ));
+    }
+
+    /**
+     * Resolves endDates for all formIds using the Caffeine cache first.
+     * Only formIds not found in the cache are forwarded to Elasticsearch,
+     * and their results are stored back into the cache for future calls.
+     */
+    private Map<String, Long> resolveEndDates(List<String> formIds) {
+        Map<String, Optional<Long>> cacheResults = formIds.stream()
+                .collect(Collectors.toMap(id -> id, cacheManager::get));
+        Map<String, Long> hits = cacheResults.entrySet().stream()
+                .filter(e -> e.getValue().isPresent())
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().orElseThrow()));
+        List<String> misses = cacheResults.entrySet().stream()
+                .filter(e -> e.getValue().isEmpty())
+                .map(Map.Entry::getKey)
+                .toList();
+        log.info("Cache resolution: {} hit(s), {} miss(es) out of {} formId(s)",
+                hits.size(), misses.size(), formIds.size());
+        if (misses.isEmpty()) {
+            return hits;
+        }
+        log.info("Querying Elasticsearch for {} uncached formId(s)", misses.size());
+        List<Map<String, Object>> esResults = fetchFormMetadata(misses);
+        log.info("Elasticsearch returned {} document(s) for {} queried formId(s)",
+                esResults.size(), misses.size());
+        Map<String, Long> esEndDates = buildFormIdToEndDateMap(esResults);
+        esEndDates.forEach(cacheManager::put);
+
+        Map<String, Long> result = new HashMap<>(hits);
+        result.putAll(esEndDates);
+        return result;
+    }
+
+    /** Terms query to Elasticsearch for the given formIds using config-driven index alias, context type, and field projection. */
+    private List<Map<String, Object>> fetchFormMetadata(List<String> formIds) {
+        return esClientService.searchByTerms(
+                cbServerProperties.getFormsEsIndexAlias(),
+                Constants.FORM_ID,
+                formIds,
+                cbServerProperties.getFormsEsContextType(),
+                cbServerProperties.getFormsEsFetchFields()
+        );
+    }
+
+    /** Sets STATUS=EXPIRED on all notifications whose form endDate is in the past; all notifications sharing an expired formId are marked. */
+    private void markExpiredRecords(Map<String, List<Map<String, Object>>> formIdToRecords,
+                                    Map<String, Long> formIdToEndDate) {
+        long now = System.currentTimeMillis();
+        List<Map<String, Object>> expired = formIdToRecords.entrySet().stream()
+                .filter(entry -> isFormExpired(formIdToEndDate.get(entry.getKey()), now))
+                .flatMap(entry -> entry.getValue().stream())
+                .toList();
+        expired.forEach(notification -> notification.put(Constants.STATUS, Constants.STATUS_EXPIRED));
+        if (expired.isEmpty()) {
+            log.info("No expired records found in this batch of {} formId(s)", formIdToRecords.size());
+        } else {
+            log.info("Marked {} of {} record(s) as {} in this batch",
+                    expired.size(), formIdToRecords.size(), Constants.STATUS_EXPIRED);
+        }
+    }
+
+    /** Returns {@code true} if {@code endDate} is non-null and strictly before {@code now}; null endDate is treated as not expired. */
+    private boolean isFormExpired(Long endDate, long now) {
+        return endDate != null && endDate < now;
+    }
+
+    /** Parses the JSON {@code metadata} field to extract {@code formId}; returns {@code null} on absent, blank, or malformed input. */
+    private String extractFormId(Map<String, Object> notification) {
+        if (!(notification.get(Constants.METADATA) instanceof String metaStr) || metaStr.isBlank()) {
+            return null;
+        }
+        try {
+            Map<String, Object> metaMap = objectMapper.readValue(metaStr, new TypeReference<>() {});
+            if (metaMap.get(Constants.FORM_ID) instanceof String formId) {
+                return formId;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to parse metadata for notification [{}]", notification.get(Constants.NOTIFICATION_ID));
+        }
+        return null;
+    }
+
+    /** Filters records to those with PENDING status (case-insensitive). */
+    private List<Map<String, Object>> filterPendingRecords(List<Map<String, Object>> records) {
+        return records.stream()
+                .filter(r -> r.get(Constants.STATUS) instanceof String status
+                        && Constants.STATUS_PENDING.equalsIgnoreCase(status))
+                .toList();
+    }
+
+    /** Builds a formId → endDate map from ES documents; tolerates missing formIds and absent endDates without error. */
+    private Map<String, Long> buildFormIdToEndDateMap(List<Map<String, Object>> esResults) {
+        if (CollectionUtils.isEmpty(esResults)) {
+            return Collections.emptyMap();
+        }
+        return esResults.stream()
+                .flatMap(esDoc -> Optional.of(esDoc)
+                        .filter(doc -> doc.get(Constants.FORM_ID) instanceof String id && !id.isBlank())
+                        .flatMap(this::extractEndDate)
+                        .map(endDate -> Map.entry((String) esDoc.get(Constants.FORM_ID), endDate))
+                        .stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /** Checks top-level {@code endDate} first, then {@code additionalProperties.endDate}; returns empty if neither yields a Number. */
+    private Optional<Long> extractEndDate(Map<String, Object> esDoc) {
+        if (esDoc.get(Constants.END_DATE) instanceof Number topLevel) {
+            return Optional.of(topLevel.longValue());
+        }
+        if (esDoc.get(Constants.ADDITIONAL_PROPERTIES) instanceof Map<?, ?> apMap
+                && apMap.get(Constants.END_DATE) instanceof Number nested) {
+            return Optional.of(nested.longValue());
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -12,6 +12,7 @@ import com.igot.cb.notification.enums.NotificationSubCategory;
 import com.igot.cb.notification.enums.NotificationSubType;
 import com.igot.cb.notification.enums.NotificationType;
 import com.igot.cb.notification.repository.NotificationSettingRepository;
+import com.igot.cb.notification.service.FormExpiryValidator;
 import com.igot.cb.notification.service.NotificationService;
 import com.igot.cb.producer.Producer;
 import com.igot.cb.util.CbServerProperties;
@@ -48,15 +49,17 @@ public class NotificationServiceImpl implements NotificationService {
     private NotificationSettingRepository notificationSettingRepository;
     private CbServerProperties cbServerProperties;
     private Producer producer;
+    private FormExpiryValidator formExpiryValidator;
     public NotificationServiceImpl(AccessTokenValidator accessTokenValidator, CassandraOperation cassandraOperation,
             ObjectMapper objectMapper, NotificationSettingRepository notificationSettingRepository,
-            CbServerProperties cbServerProperties, Producer producer) {
+            CbServerProperties cbServerProperties, Producer producer, FormExpiryValidator formExpiryValidator) {
         this.accessTokenValidator = accessTokenValidator;
         this.cassandraOperation = cassandraOperation;
         this.objectMapper = objectMapper;
         this.notificationSettingRepository = notificationSettingRepository;
         this.cbServerProperties = cbServerProperties;
         this.producer = producer;
+        this.formExpiryValidator = formExpiryValidator;
     }
 
     private final Logger logger = LoggerFactory.getLogger(NotificationServiceImpl.class);
@@ -2312,39 +2315,13 @@ public class NotificationServiceImpl implements NotificationService {
                 records.size(), fromDate, excludedStatuses);
         Set<String> exclusionSet = CollectionUtils.isEmpty(excludedStatuses)
                 ? Collections.emptySet() : new HashSet<>(excludedStatuses);
-        Instant now = Instant.now();
-        records.forEach(r -> markAsExpiredIfEligible(r, now));
+        formExpiryValidator.validateAndMarkExpired(records);
         List<Map<String, Object>> result = records.stream()
                 .filter(r -> isWithinDateWindow(r, fromDate) && isStatusAllowed(r, exclusionSet))
                 .sorted(Comparator.comparing(r -> getInstant(r.get(SURVEY_END_DATE))))
                 .toList();
         log.debug("filterSortAndLimit: output={} records after filtering and sorting", result.size());
         return result;
-    }
-
-    /**
-     * Mutates a single record in-memory by setting its {@code status} to {@code EXPIRED}
-     * when all of the following hold:
-     * <ul>
-     *   <li>The current status is {@code PENDING} (case-insensitive).</li>
-     *   <li>A {@code survey_end_date} is present on the record.</li>
-     *   <li>{@code survey_end_date} is strictly before {@code now}.</li>
-     * </ul>
-     * Non-PENDING records are skipped immediately. No Cassandra write is performed.
-     *
-     * @param record the peer-validation record map to evaluate and potentially mutate
-     * @param now    the reference instant used as the expiry threshold
-     */
-    private void markAsExpiredIfEligible(Map<String, Object> notifRecord, Instant now) {
-        if (!Constants.STATUS_PENDING.equalsIgnoreCase((String) notifRecord.get(STATUS))) {
-            return;
-        }
-        Instant surveyEndDate = getInstant(notifRecord.get(SURVEY_END_DATE));
-        if (!ObjectUtils.isEmpty(surveyEndDate) && surveyEndDate.isBefore(now)) {
-            notifRecord.put(STATUS, Constants.STATUS_EXPIRED);
-            log.info("Marked record as EXPIRED in-memory: userId={}, notificationId={}",
-                    notifRecord.get(USER_ID), notifRecord.get(NOTIFICATION_ID));
-        }
     }
 
     /**

--- a/src/main/java/com/igot/cb/transactional/caffeinecache/NotificationMetadataCacheManager.java
+++ b/src/main/java/com/igot/cb/transactional/caffeinecache/NotificationMetadataCacheManager.java
@@ -1,0 +1,78 @@
+package com.igot.cb.transactional.caffeinecache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.igot.cb.util.CbServerProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Caffeine-backed in-process cache mapping form IDs to their {@code endDate}
+ * epoch-millis. This is a pure read-through store — callers are responsible
+ * for fetching from Elasticsearch on a miss and warming the cache via {@link #put}.
+ *
+ * <p>TTL and maximum capacity are controlled by {@code forms.cache.ttl.seconds}
+ * and {@code forms.cache.max.size} in {@code application.properties}.</p>
+ */
+@Service
+@Slf4j
+public class NotificationMetadataCacheManager {
+
+    private final CbServerProperties cbServerProperties;
+
+    /** Key: formId, Value: endDate epoch-millis. */
+    private Cache<String, Long> cache;
+
+    public NotificationMetadataCacheManager(CbServerProperties cbServerProperties) {
+        this.cbServerProperties = cbServerProperties;
+    }
+
+    /** Builds the Caffeine cache once config-driven TTL and max-size values are available. */
+    @PostConstruct
+    public void initCache() {
+        cache = Caffeine.newBuilder()
+                .maximumSize(cbServerProperties.getFormsCacheMaxSize())
+                .expireAfterWrite(cbServerProperties.getFormsCacheTtlSeconds(), TimeUnit.SECONDS)
+                .build();
+        log.info("NotificationMetadataCacheManager initialised — TTL={}s, maxSize={}",
+                cbServerProperties.getFormsCacheTtlSeconds(),
+                cbServerProperties.getFormsCacheMaxSize());
+    }
+
+    /**
+     * Returns the cached {@code endDate} for {@code formId}, or {@link Optional#empty()}
+     * on a cache miss. Callers are responsible for querying Elasticsearch on a miss
+     * and warming the cache via {@link #put}.
+     */
+    public Optional<Long> get(String formId) {
+        Long cached = cache.getIfPresent(formId);
+        if (cached != null) {
+            log.debug("Cache hit for formId={}", formId);
+            return Optional.of(cached);
+        }
+        log.debug("Cache miss for formId={}", formId);
+        return Optional.empty();
+    }
+
+    /** Warms the cache explicitly; useful for bulk callers that already hold ES results. */
+    public void put(String formId, Long endDate) {
+        cache.put(formId, endDate);
+        log.info("Cache warmed: formId={}, endDate={}", formId, endDate);
+    }
+
+    /** Evicts {@code formId} so the next {@link #get} call reloads from Elasticsearch. */
+    public void invalidate(String formId) {
+        cache.invalidate(formId);
+        log.debug("Cache entry invalidated for formId={}", formId);
+    }
+
+    /** Clears all entries; all subsequent {@link #get} calls will return empty until re-warmed. */
+    public void invalidateAll() {
+        cache.invalidateAll();
+        log.info("NotificationMetadataCacheManager: full cache invalidation");
+    }
+}

--- a/src/main/java/com/igot/cb/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbServerProperties.java
@@ -120,4 +120,22 @@ public class CbServerProperties {
   @Value("${mandatory.notification.max.fetch.limit:100}")
   private int mandatoryNotificationMaxFetchLimit;
 
+  @Value("${forms.es.index.alias}")
+  private String formsEsIndexAlias;
+
+  @Value("${forms.es.context.type}")
+  private String formsEsContextType;
+
+  @Value("#{'${forms.es.fetch.fields}'.split(',')}")
+  private List<String> formsEsFetchFields;
+
+  @Value("${forms.es.fetch.batch.size}")
+  private int formsEsFetchBatchSize;
+
+  @Value("${forms.cache.ttl.seconds}")
+  private long formsCacheTtlSeconds;
+
+  @Value("${forms.cache.max.size}")
+  private long formsCacheMaxSize;
+
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -562,6 +562,17 @@ public class Constants {
     public static final String ERR_UPDATING_NOTIFICATION = "Internal server error while updating notification";
     public static final String TABLE_MANDATORY_NOTIFICATION = "mandatory_notifications";
 
+    public static final String ES_HTTP_SCHEME = "http";
+    public static final String ES_PRODUCT_HEADER = "X-Elastic-Product";
+    public static final String ES_PRODUCT_HEADER_VALUE = "Elasticsearch";
+    public static final String ES_MGET_UNKNOWN_REASON = "unknown";
+    public static final String ES_LOG_INVALID_INPUT =
+            "readDocuments skipped: invalid input (index='{}', idCount={})";
+    public static final String ES_LOG_MGET_FAILURE =
+            "mget failure for index [{}] id [{}]: {}";
+    public static final String ES_LOG_READ_ERROR =
+            "Error reading documents from ES for index [{}]: {}";
+    public static final String END_DATE = "endDate";
     private Constants() {
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -112,3 +112,26 @@ cleanup.peer.validation.audit.deletion.prefix=DELETED:
 
 #Mandatory Notification
 mandatory.notification.max.fetch.limit=100
+
+
+#Elasticsearch Configuration
+elasticsearch.host=localhost
+elasticsearch.port=9200
+elasticsearch.username=
+elasticsearch.password=
+#Forms (Elasticsearch) lookup for peer-validation survey expiry
+forms.es.index.alias=fs-forms-alias-v2
+forms.es.context.type=peerValidationSurvey
+# Comma-separated list of _source fields fetched per form document
+forms.es.fetch.fields=formId,additionalProperties
+# Number of formIds resolved against Elasticsearch in a single _mget round-trip
+forms.es.fetch.batch.size=10
+# Caffeine in-process cache for form metadata (endDate per formId)
+# TTL in seconds after which a cached entry is evicted (default: 1 day)
+forms.cache.ttl.seconds=86400
+# Maximum number of formId entries held in the cache at any time
+forms.cache.max.size=5000
+# Elasticsearch query guard: max values allowed in a single terms query (ES hard limit: 65536)
+es.max.terms.count=65536
+# Elasticsearch query timeout passed to ES at the shard level
+es.query.timeout=5s

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -115,7 +115,7 @@ mandatory.notification.max.fetch.limit=100
 
 
 #Elasticsearch Configuration
-elasticsearch.host=localhost
+elasticsearch.hosts=localhost
 elasticsearch.port=9200
 elasticsearch.username=
 elasticsearch.password=

--- a/src/test/java/com/igot/cb/elasticsearch/service/EsClientServiceImplTest.java
+++ b/src/test/java/com/igot/cb/elasticsearch/service/EsClientServiceImplTest.java
@@ -1,0 +1,168 @@
+package com.igot.cb.elasticsearch.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EsClientServiceImplTest {
+
+    @Mock
+    private ElasticsearchClient elasticsearchClient;
+
+    private EsClientServiceImpl esClientService;
+
+    private static final String INDEX = "forms-index";
+    private static final String FIELD = "formId";
+    private static final String CONTEXT_TYPE = "survey";
+    private static final int MAX_TERMS = 100;
+    private static final String TIMEOUT = "5s";
+
+    @BeforeEach
+    void setUp() {
+        esClientService = new EsClientServiceImpl(elasticsearchClient);
+        ReflectionTestUtils.setField(esClientService, "maxTermsCount", MAX_TERMS);
+        ReflectionTestUtils.setField(esClientService, "queryTimeout", TIMEOUT);
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenIndexNameIsBlank() throws IOException {
+        List<Map<String, Object>> result = esClientService.searchByTerms("", FIELD, List.of("v1"), CONTEXT_TYPE, null);
+        assertTrue(result.isEmpty());
+        verify(elasticsearchClient, never()).search(any(SearchRequest.class), any());
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenIndexNameIsNull() throws IOException {
+        List<Map<String, Object>> result = esClientService.searchByTerms(null, FIELD, List.of("v1"), CONTEXT_TYPE, null);
+        assertTrue(result.isEmpty());
+        verify(elasticsearchClient, never()).search(any(SearchRequest.class), any());
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenFieldNameIsBlank() throws IOException {
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, "", List.of("v1"), CONTEXT_TYPE, null);
+        assertTrue(result.isEmpty());
+        verify(elasticsearchClient, never()).search(any(SearchRequest.class), any());
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenValuesIsNull() throws IOException {
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, FIELD, null, CONTEXT_TYPE, null);
+        assertTrue(result.isEmpty());
+        verify(elasticsearchClient, never()).search(any(SearchRequest.class), any());
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenValuesIsEmpty() throws IOException {
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, FIELD, Collections.emptyList(), CONTEXT_TYPE, null);
+        assertTrue(result.isEmpty());
+        verify(elasticsearchClient, never()).search(any(SearchRequest.class), any());
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenValuesExceedMaxTermsCount() throws IOException {
+        List<String> oversizedValues = Collections.nCopies(MAX_TERMS + 1, "formId");
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, FIELD, oversizedValues, CONTEXT_TYPE, null);
+        assertTrue(result.isEmpty());
+        verify(elasticsearchClient, never()).search(any(SearchRequest.class), any());
+    }
+
+    @Test
+    void shouldReturnDocumentsOnSuccessfulSearch() throws IOException {
+        Map<String, Object> sourceDoc = Map.of("formId", "form-001", "endDate", 123456789L);
+        mockEsResponse(List.of(sourceDoc));
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, FIELD, List.of("form-001"), CONTEXT_TYPE, null);
+        assertEquals(1, result.size());
+        assertEquals("form-001", result.get(0).get("formId"));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenEsThrowsIoException() throws IOException {
+        when(elasticsearchClient.search(any(SearchRequest.class), any())).thenThrow(new IOException("ES down"));
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, FIELD, List.of("v1"), CONTEXT_TYPE, null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldFilterOutNullSourceHits() throws IOException {
+        mockEsResponseWithNullSource();
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, FIELD, List.of("v1"), CONTEXT_TYPE, null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldWorkWithBlankContextType() throws IOException {
+        Map<String, Object> sourceDoc = Map.of("formId", "form-001");
+        mockEsResponse(List.of(sourceDoc));
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, FIELD, List.of("form-001"), "", null);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void shouldWorkWithNullContextType() throws IOException {
+        Map<String, Object> sourceDoc = Map.of("formId", "form-001");
+        mockEsResponse(List.of(sourceDoc));
+        List<Map<String, Object>> result = esClientService.searchByTerms(INDEX, FIELD, List.of("form-001"), null, null);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void shouldReturnMultipleDocumentsWhenMultipleHitsExist() throws IOException {
+        List<Map<String, Object>> docs = List.of(
+                Map.of("formId", "form-001"),
+                Map.of("formId", "form-002"),
+                Map.of("formId", "form-003"));
+        mockEsResponse(docs);
+        List<Map<String, Object>> result = esClientService.searchByTerms(
+                INDEX, FIELD, List.of("form-001", "form-002", "form-003"), CONTEXT_TYPE, null);
+        assertEquals(3, result.size());
+    }
+
+    private void mockEsResponse(List<Map<String, Object>> sources) throws IOException {
+        SearchResponse<Map<String, Object>> response = mock(SearchResponse.class);
+        HitsMetadata<Map<String, Object>> hitsMetadata = mock(HitsMetadata.class);
+        List<Hit<Map<String, Object>>> hits = sources.stream()
+                .map(src -> {
+                    Hit<Map<String, Object>> hit = mock(Hit.class);
+                    when(hit.source()).thenReturn(src);
+                    return hit;
+                })
+                .toList();
+        when(response.hits()).thenReturn(hitsMetadata);
+        when(hitsMetadata.hits()).thenReturn(hits);
+        doReturn(response).when(elasticsearchClient).search(any(SearchRequest.class), any());
+    }
+
+    private void mockEsResponseWithNullSource() throws IOException {
+        SearchResponse<Map<String, Object>> response = mock(SearchResponse.class);
+        HitsMetadata<Map<String, Object>> hitsMetadata = mock(HitsMetadata.class);
+        Hit<Map<String, Object>> hit = mock(Hit.class);
+        when(hit.source()).thenReturn(null);
+        when(response.hits()).thenReturn(hitsMetadata);
+        when(hitsMetadata.hits()).thenReturn(List.of(hit));
+        doReturn(response).when(elasticsearchClient).search(any(SearchRequest.class), any());
+    }
+}

--- a/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/BulkPeerValidationNotificationTest.java
@@ -3,6 +3,7 @@ package com.igot.cb.notification.service.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.notification.entity.NotificationSettingEntity;
 import com.igot.cb.notification.repository.NotificationSettingRepository;
+import com.igot.cb.notification.service.FormExpiryValidator;
 import com.igot.cb.producer.Producer;
 import com.igot.cb.util.CbServerProperties;
 import com.igot.cb.util.Constants;
@@ -46,6 +47,9 @@ class BulkPeerValidationNotificationTest {
 
     @Mock
     private Producer producer;
+
+    @Mock
+    private FormExpiryValidator formExpiryValidator;
 
     private final ObjectMapper realMapper = new ObjectMapper();
 
@@ -608,6 +612,19 @@ class BulkPeerValidationNotificationTest {
                     .thenReturn(List.of("SUBMITTED", "IGNORED"));
             when(cbServerProperties.getPeerReviewAssignedExcludedStatuses())
                     .thenReturn(List.of("APPROVED", "REJECTED"));
+            doAnswer(invocation -> {
+                List<Map<String, Object>> recs = invocation.getArgument(0);
+                Instant now = Instant.now();
+                recs.forEach(r -> {
+                    if (STATUS_PENDING.equalsIgnoreCase((String) r.get(Constants.STATUS))) {
+                        Object sed = r.get(Constants.SURVEY_END_DATE);
+                        if (sed instanceof Instant && ((Instant) sed).isBefore(now)) {
+                            r.put(Constants.STATUS, STATUS_EXPIRED);
+                        }
+                    }
+                });
+                return recs;
+            }).when(formExpiryValidator).validateAndMarkExpired(anyList());
         }
         private Map<String, Object> buildRecord(String status, Instant createdAt) {
             Map<String, Object> r = new HashMap<>();

--- a/src/test/java/com/igot/cb/notification/service/impl/FormExpiryValidatorImplTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/FormExpiryValidatorImplTest.java
@@ -1,0 +1,252 @@
+package com.igot.cb.notification.service.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.igot.cb.elasticsearch.service.EsClientService;
+import com.igot.cb.transactional.caffeinecache.NotificationMetadataCacheManager;
+import com.igot.cb.util.CbServerProperties;
+import com.igot.cb.util.Constants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.quality.Strictness;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class FormExpiryValidatorImplTest {
+
+    @Mock
+    private EsClientService esClientService;
+    @Mock
+    private CbServerProperties cbServerProperties;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private NotificationMetadataCacheManager cacheManager;
+
+    @InjectMocks
+    private FormExpiryValidatorImpl validator;
+
+    private static final String FORM_ID_1 = "form-001";
+    private static final String INDEX_ALIAS = "forms-index";
+    private static final String CONTEXT_TYPE = "survey";
+    private static final long PAST_END_DATE = System.currentTimeMillis() - 86_400_000L;
+    private static final long FUTURE_END_DATE = System.currentTimeMillis() + 86_400_000L;
+
+    @BeforeEach
+    void setUp() {
+        when(cbServerProperties.getFormsEsFetchBatchSize()).thenReturn(10);
+        when(cbServerProperties.getFormsEsIndexAlias()).thenReturn(INDEX_ALIAS);
+        when(cbServerProperties.getFormsEsContextType()).thenReturn(CONTEXT_TYPE);
+        when(cbServerProperties.getFormsEsFetchFields()).thenReturn(List.of(Constants.FORM_ID, Constants.END_DATE));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenRecordsIsNull() {
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(null);
+        assertTrue(result.isEmpty());
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenRecordsIsEmpty() {
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(Collections.emptyList());
+        assertTrue(result.isEmpty());
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldReturnOriginalListWhenNoPendingRecordsExist() {
+        Map<String, Object> notification = Map.of(Constants.STATUS, Constants.STATUS_EXPIRED);
+        List<Map<String, Object>> records = List.of(notification);
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(records);
+        assertEquals(records, result);
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldMarkRecordExpiredWhenEndDateIsInPast() throws Exception {
+        Map<String, Object> notification = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, FORM_ID_1));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(PAST_END_DATE));
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+        assertEquals(Constants.STATUS_EXPIRED, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldNotMarkRecordExpiredWhenEndDateIsInFuture() throws Exception {
+        Map<String, Object> notification = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, FORM_ID_1));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(FUTURE_END_DATE));
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+    }
+
+    @Test
+    void shouldNotMarkRecordExpiredWhenNoEndDateFound() throws Exception {
+        Map<String, Object> notification = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, FORM_ID_1));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.empty());
+        when(esClientService.searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList()))
+                .thenReturn(Collections.emptyList());
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+    }
+
+    @Test
+    void shouldFetchFromEsOnCacheMissAndWarmCache() throws Exception {
+        Map<String, Object> notification = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        Map<String, Object> esDoc = Map.of(Constants.FORM_ID, FORM_ID_1, Constants.END_DATE, PAST_END_DATE);
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, FORM_ID_1));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.empty());
+        when(esClientService.searchByTerms(eq(INDEX_ALIAS), eq(Constants.FORM_ID), eq(List.of(FORM_ID_1)),
+                eq(CONTEXT_TYPE), anyList())).thenReturn(List.of(esDoc));
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+        assertEquals(Constants.STATUS_EXPIRED, result.get(0).get(Constants.STATUS));
+        verify(cacheManager).put(FORM_ID_1, PAST_END_DATE);
+    }
+
+    @Test
+    void shouldFetchFromEsOnlyForCacheMissesWhenPartialCacheHit() throws Exception {
+        String formId2 = "form-002";
+        Map<String, Object> record1 = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        Map<String, Object> record2 = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + formId2 + "\"}");
+        Map<String, Object> esDoc = Map.of(Constants.FORM_ID, formId2, Constants.END_DATE, PAST_END_DATE);
+        when(objectMapper.readValue(eq("{\"formId\":\"" + FORM_ID_1 + "\"}"), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, FORM_ID_1));
+        when(objectMapper.readValue(eq("{\"formId\":\"" + formId2 + "\"}"), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, formId2));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(FUTURE_END_DATE));
+        when(cacheManager.get(formId2)).thenReturn(Optional.empty());
+        when(esClientService.searchByTerms(eq(INDEX_ALIAS), eq(Constants.FORM_ID), eq(List.of(formId2)),
+                eq(CONTEXT_TYPE), anyList())).thenReturn(List.of(esDoc));
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(record1, record2));
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        assertEquals(Constants.STATUS_EXPIRED, result.get(1).get(Constants.STATUS));
+        verify(esClientService, times(1)).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldSkipRecordWithBlankMetadata() {
+        Map<String, Object> notification = mutableRecord(Constants.STATUS_PENDING, "");
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldSkipRecordWithNullMetadata() {
+        Map<String, Object> notification = mutableRecord(Constants.STATUS_PENDING, null);
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldSkipRecordAndContinueBatchWhenMetadataIsMalformed() throws Exception {
+        Map<String, Object> badNotification = mutableRecord(Constants.STATUS_PENDING, "{invalid-json}");
+        when(objectMapper.readValue(eq("{invalid-json}"), any(TypeReference.class)))
+                .thenThrow(new RuntimeException("parse error"));
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(badNotification));
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldExtractEndDateFromAdditionalPropertiesWhenTopLevelAbsent() throws Exception {
+        Map<String, Object> notification = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        Map<String, Object> esDoc = Map.of(
+                Constants.FORM_ID, FORM_ID_1,
+                Constants.ADDITIONAL_PROPERTIES, Map.of(Constants.END_DATE, PAST_END_DATE));
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, FORM_ID_1));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.empty());
+        when(esClientService.searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList()))
+                .thenReturn(List.of(esDoc));
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+        assertEquals(Constants.STATUS_EXPIRED, result.get(0).get(Constants.STATUS));
+    }
+
+    @Test
+    void shouldProcessMultipleBatchesWhenRecordsExceedBatchSize() throws Exception {
+        when(cbServerProperties.getFormsEsFetchBatchSize()).thenReturn(2);
+        List<Map<String, Object>> records = List.of(
+                pendingRecordWithFormId("form-a"),
+                pendingRecordWithFormId("form-b"),
+                pendingRecordWithFormId("form-c"));
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenAnswer(invocation -> {
+                    String json = invocation.getArgument(0);
+                    String id = json.replaceAll(".*\"formId\":\"([^\"]+)\".*", "$1");
+                    return Map.of(Constants.FORM_ID, id);
+                });
+        when(cacheManager.get(anyString())).thenReturn(Optional.empty());
+        when(esClientService.searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList()))
+                .thenReturn(Collections.emptyList());
+        validator.validateAndMarkExpired(records);
+        verify(esClientService, times(2)).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldMarkAllNotificationsExpiredWhenMultipleShareSameFormId() throws Exception {
+        Map<String, Object> notif1 = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        Map<String, Object> notif2 = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        Map<String, Object> notif3 = mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, FORM_ID_1));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(PAST_END_DATE));
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notif1, notif2, notif3));
+        assertEquals(Constants.STATUS_EXPIRED, result.get(0).get(Constants.STATUS));
+        assertEquals(Constants.STATUS_EXPIRED, result.get(1).get(Constants.STATUS));
+        assertEquals(Constants.STATUS_EXPIRED, result.get(2).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldHandlePendingStatusCaseInsensitively() throws Exception {
+        Map<String, Object> notification = mutableRecord("pending", "{\"formId\":\"" + FORM_ID_1 + "\"}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.FORM_ID, FORM_ID_1));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(PAST_END_DATE));
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+        assertEquals(Constants.STATUS_EXPIRED, result.get(0).get(Constants.STATUS));
+    }
+
+    private Map<String, Object> mutableRecord(String status, String metadata) {
+        Map<String, Object> notification = new HashMap<>();
+        notification.put(Constants.STATUS, status);
+        notification.put(Constants.METADATA, metadata);
+        notification.put(Constants.NOTIFICATION_ID, "notif-" + System.nanoTime());
+        return notification;
+    }
+
+    private Map<String, Object> pendingRecordWithFormId(String formId) {
+        return mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + formId + "\"}");
+    }
+}

--- a/src/test/java/com/igot/cb/transactional/caffeinecache/NotificationMetadataCacheManagerTest.java
+++ b/src/test/java/com/igot/cb/transactional/caffeinecache/NotificationMetadataCacheManagerTest.java
@@ -1,0 +1,85 @@
+package com.igot.cb.transactional.caffeinecache;
+
+import com.igot.cb.util.CbServerProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationMetadataCacheManagerTest {
+
+    @Mock
+    private CbServerProperties cbServerProperties;
+
+    private NotificationMetadataCacheManager cacheManager;
+
+    private static final String FORM_ID = "form-001";
+    private static final long END_DATE_MILLIS = System.currentTimeMillis() + 86_400_000L;
+
+    @BeforeEach
+    void setUp() {
+        when(cbServerProperties.getFormsCacheTtlSeconds()).thenReturn(300L);
+        when(cbServerProperties.getFormsCacheMaxSize()).thenReturn(100L);
+        cacheManager = new NotificationMetadataCacheManager(cbServerProperties);
+        cacheManager.initCache();
+    }
+
+    @Test
+    void shouldReturnEmptyOnCacheMiss() {
+        Optional<Long> result = cacheManager.get(FORM_ID);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldReturnValueAfterExplicitPut() {
+        cacheManager.put(FORM_ID, END_DATE_MILLIS);
+        Optional<Long> result = cacheManager.get(FORM_ID);
+        assertTrue(result.isPresent());
+        assertEquals(END_DATE_MILLIS, result.get());
+    }
+
+    @Test
+    void shouldReturnCachedValueOnSubsequentGet() {
+        cacheManager.put(FORM_ID, END_DATE_MILLIS);
+        assertEquals(Optional.of(END_DATE_MILLIS), cacheManager.get(FORM_ID));
+        assertEquals(Optional.of(END_DATE_MILLIS), cacheManager.get(FORM_ID));
+    }
+
+    @Test
+    void shouldReturnEmptyAfterInvalidatingSingleKey() {
+        cacheManager.put(FORM_ID, END_DATE_MILLIS);
+        cacheManager.invalidate(FORM_ID);
+        assertTrue(cacheManager.get(FORM_ID).isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyAfterInvalidateAll() {
+        cacheManager.put(FORM_ID, END_DATE_MILLIS);
+        cacheManager.put("form-002", END_DATE_MILLIS);
+        cacheManager.invalidateAll();
+        assertTrue(cacheManager.get(FORM_ID).isEmpty());
+        assertTrue(cacheManager.get("form-002").isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyForKeyNeverPut() {
+        cacheManager.put("other-form", END_DATE_MILLIS);
+        assertTrue(cacheManager.get(FORM_ID).isEmpty());
+    }
+
+    @Test
+    void shouldOverwriteExistingValueOnReput() {
+        long newEndDate = END_DATE_MILLIS + 10_000L;
+        cacheManager.put(FORM_ID, END_DATE_MILLIS);
+        cacheManager.put(FORM_ID, newEndDate);
+        assertEquals(Optional.of(newEndDate), cacheManager.get(FORM_ID));
+    }
+}


### PR DESCRIPTION
Introduces a FormExpiryValidator that marks PENDING peer-validation notifications as EXPIRED when their form's endDate has passed.

- Looks up form endDates from Elasticsearch in configurable batches
- Caffeine cache (TTL 1 day, max 5000 entries) sits in front of ES to avoid redundant round-trips
- Cache is a pure store — ES is only called on a cache miss
- NotificationServiceImpl delegates expiry marking to FormExpiryValidator instead of doing it inline
- All new classes covered by unit tests; existing GetPeerValidationList tests fixed by adding a FormExpiryValidator mock with a SURVEY_END_DATE stub
