### PR TITLE
KB-13847 | Users can still access and complete survey after manual end via notification

### DIFF
--- a/src/main/java/com/igot/cb/notification/service/impl/FormExpiryValidatorImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/FormExpiryValidatorImpl.java
@@ -155,10 +155,10 @@ public class FormExpiryValidatorImpl implements FormExpiryValidator {
         return endDate != null && endDate < now;
     }
 
-    /** Parses the JSON {@code metadata} field to extract {@code formId}; returns {@code null} on absent, blank, or malformed input. */
+    /** Parses the JSON {@code metadata} field to extract {@code formId}; falls back to {@code message.data[0].formId} for {@code notifications} table records. Returns {@code null} on absent, blank, or malformed input. */
     private String extractFormId(Map<String, Object> notification) {
         if (!(notification.get(Constants.METADATA) instanceof String metaStr) || metaStr.isBlank()) {
-            return null;
+            return extractFormIdFromMessage(notification);
         }
         try {
             Map<String, Object> metaMap = objectMapper.readValue(metaStr, new TypeReference<>() {});
@@ -168,7 +168,8 @@ public class FormExpiryValidatorImpl implements FormExpiryValidator {
         } catch (Exception e) {
             log.warn("Failed to parse metadata for notification [{}]", notification.get(Constants.NOTIFICATION_ID));
         }
-        return null;
+        // Fallback: notifications table stores formId inside message.data[0].formId
+        return extractFormIdFromMessage(notification);
     }
 
     /** Filters records to those with PENDING status (case-insensitive). */
@@ -203,5 +204,23 @@ public class FormExpiryValidatorImpl implements FormExpiryValidator {
             return Optional.of(nested.longValue());
         }
         return Optional.empty();
+    }
+
+    /** Parses the JSON {@code message} field to extract {@code formId} from {@code data[0]}; returns {@code null} on absent, blank, or malformed input. */
+    private String extractFormIdFromMessage(Map<String, Object> notification) {
+        if (!(notification.get(Constants.MESSAGE) instanceof String msgStr) || msgStr.isBlank()) {
+            return null;
+        }
+        try {
+            Map<String, Object> msgMap = objectMapper.readValue(msgStr, new TypeReference<>() {});
+            if (msgMap.get(Constants.DATA) instanceof List<?> dataList && !dataList.isEmpty()
+                    && dataList.get(0) instanceof Map<?, ?> firstEntry
+                    && firstEntry.get(Constants.FORM_ID) instanceof String formId) {
+                return formId;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to parse message for notification [{}]", notification.get(Constants.NOTIFICATION_ID));
+        }
+        return null;
     }
 }

--- a/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/igot/cb/notification/service/impl/NotificationServiceImpl.java
@@ -553,7 +553,7 @@ public class NotificationServiceImpl implements NotificationService {
 
             List<Map<String, Object>> peerValidationNotifs = merged.stream()
                     .filter(n -> CATEGORY_PEER_VALIDATION.equalsIgnoreCase((String) n.get(CATEGORY)))
-                    .collect(Collectors.toList());
+                    .toList();
             if (!peerValidationNotifs.isEmpty()) {
                 formExpiryValidator.validateAndMarkExpired(peerValidationNotifs);
             }

--- a/src/test/java/com/igot/cb/notification/service/impl/FormExpiryValidatorImplTest.java
+++ b/src/test/java/com/igot/cb/notification/service/impl/FormExpiryValidatorImplTest.java
@@ -249,4 +249,131 @@ class FormExpiryValidatorImplTest {
     private Map<String, Object> pendingRecordWithFormId(String formId) {
         return mutableRecord(Constants.STATUS_PENDING, "{\"formId\":\"" + formId + "\"}");
     }
+
+
+    @Test
+    void shouldMarkExpiredWhenFormIdExtractedFromMessageAndEndDateInPast() throws Exception {
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, null,
+                "{\"data\":[{\"formId\":\"" + FORM_ID_1 + "\"}]}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.DATA, List.of(Map.of(Constants.FORM_ID, FORM_ID_1))));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(PAST_END_DATE));
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_EXPIRED, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldNotMarkExpiredWhenFormIdExtractedFromMessageAndEndDateInFuture() throws Exception {
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, null,
+                "{\"data\":[{\"formId\":\"" + FORM_ID_1 + "\"}]}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.DATA, List.of(Map.of(Constants.FORM_ID, FORM_ID_1))));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(FUTURE_END_DATE));
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+    }
+
+    @Test
+    void shouldSkipRecordWhenMetadataAbsentAndMessageIsBlank() {
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, null, "");
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldSkipRecordWhenMetadataAbsentAndMessageIsNull() {
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, null, null);
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldSkipRecordWhenMetadataAbsentAndMessageIsMalformed() throws Exception {
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, null, "{bad-json}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenThrow(new RuntimeException("parse error"));
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldSkipRecordWhenMetadataAbsentAndMessageDataIsEmpty() throws Exception {
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, null,
+                "{\"data\":[]}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.DATA, List.of()));
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldSkipRecordWhenMetadataAbsentAndMessageDataHasNoFormId() throws Exception {
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, null,
+                "{\"data\":[{\"courseName\":\"Test\"}]}");
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.DATA, List.of(Map.of("courseName", "Test"))));
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_PENDING, result.get(0).get(Constants.STATUS));
+        verify(esClientService, never()).searchByTerms(anyString(), anyString(), anyList(), anyString(), anyList());
+    }
+
+    @Test
+    void shouldFallbackToMessageWhenMetadataParseFails() throws Exception {
+        String metaJson = "{invalid}";
+        String msgJson = "{\"data\":[{\"formId\":\"" + FORM_ID_1 + "\"}]}";
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, metaJson, msgJson);
+        when(objectMapper.readValue(eq(metaJson), any(TypeReference.class)))
+                .thenThrow(new RuntimeException("parse error"));
+        when(objectMapper.readValue(eq(msgJson), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.DATA, List.of(Map.of(Constants.FORM_ID, FORM_ID_1))));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(PAST_END_DATE));
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_EXPIRED, result.get(0).get(Constants.STATUS));
+    }
+
+    @Test
+    void shouldFallbackToMessageWhenMetadataHasNoFormId() throws Exception {
+        String metaJson = "{\"someOtherField\":\"value\"}";
+        String msgJson = "{\"data\":[{\"formId\":\"" + FORM_ID_1 + "\"}]}";
+        Map<String, Object> notification = mutableNotificationRecord(Constants.STATUS_PENDING, metaJson, msgJson);
+        when(objectMapper.readValue(eq(metaJson), any(TypeReference.class)))
+                .thenReturn(Map.of("someOtherField", "value"));
+        when(objectMapper.readValue(eq(msgJson), any(TypeReference.class)))
+                .thenReturn(Map.of(Constants.DATA, List.of(Map.of(Constants.FORM_ID, FORM_ID_1))));
+        when(cacheManager.get(FORM_ID_1)).thenReturn(Optional.of(PAST_END_DATE));
+
+        List<Map<String, Object>> result = validator.validateAndMarkExpired(List.of(notification));
+
+        assertEquals(Constants.STATUS_EXPIRED, result.get(0).get(Constants.STATUS));
+    }
+
+    private Map<String, Object> mutableNotificationRecord(String status, String metadata, String message) {
+        Map<String, Object> notification = new HashMap<>();
+        notification.put(Constants.STATUS, status);
+        notification.put(Constants.METADATA, metadata);
+        notification.put(Constants.MESSAGE, message);
+        notification.put(Constants.NOTIFICATION_ID, "notif-" + System.nanoTime());
+        return notification;
+    }
 }


### PR DESCRIPTION
The notifications table stores formId inside message.data[0].formId rather than the metadata field used by peer_validation_requests.

- extractFormId now falls back to extractFormIdFromMessage when metadata is absent, blank, or contains no formId key
- extractFormIdFromMessage extracted as a private helper method
- No interface changes; existing validateAndMarkExpired call site in NotificationServiceImpl handles both tables transparently
- Added 8 unit tests covering all fallback paths